### PR TITLE
enable clear button

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -5,7 +5,7 @@
       <div class="col d-flex align-items-center justify-content-center">
         <div class="col-auto d-flex align-items-center justify-content-end">
           <button type="button" class="btn btn-danger m-1" data-bs-toggle="tooltip" data-translate="buttons.clear"
-            id="button-form-reset" disabled data-translate-tooltip="buttons.clearTooltip">
+            id="button-form-reset" data-translate-tooltip="buttons.clearTooltip">
             Clear
           </button>
           <button class="btn btn-primary m-1" type="button" id="button-form-load" data-action="load"


### PR DESCRIPTION
Warum auch immer: Der Clearbutton war kaputt, jetzt geht er wieder.

## Changes
ich habe das wort disabled aus dem Clear Button entfernt

## Notes for Reviewer
--

## Checklist
- [ ] Mein Code folgt dem Style Guide.
- [ ] Ich habe selbst eine Code Review durchgeführt.
- [ ] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [ ] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [ ] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
Ich wüsste gerne, warum das passiert ist und wie sich sowas in Zukunft verhindern lässt.
