### PR TITLE
Hotfix: Wrong CSS-Syntax

### DIFF
--- a/css/gfz-cd.css
+++ b/css/gfz-cd.css
@@ -162,6 +162,7 @@ label.mandatory-field::after {
     /* Light grey background for normal mode */
     color: #6c757d;
     /* Grey text color */
+}
 
 .settings-menu-link {
     text-decoration: none;


### PR DESCRIPTION
Dieser Pull Request fixt das Problem, dass die **CSS-Datei `css\gfz-cd.css` nicht geladen** werden kann, weil die Syntax der CSS-Datei durch einen Merge beschädigt wurde.

## Changes
[Welche Änderungen hast du hierfür vorgenommen?]

## Notes for Reviewer
[Beschreibung der notwendigen Testschritte]

## Checklist
- [ ] Mein Code folgt dem Style Guide.
- [ ] Ich habe selbst eine Code Review durchgeführt.
- [ ] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [ ] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [ ] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
[Welche Probleme mit niedrigerer Priorität bestehen noch?]
