### PR TITLE
API: Moved API endpoint for CGI Simple Lithology vocabulary to new APIv2

### DIFF
--- a/api/v2/controllers/VocabController.php
+++ b/api/v2/controllers/VocabController.php
@@ -356,6 +356,30 @@ class VocabController
     }
 
     /**
+     * Retrieves CGI Simple Lithology keywords from a local JSON file and returns them as JSON.
+     *
+     * @return void
+     */
+    public function getCGIKeywords()
+    {
+        try {
+            $jsonPath = __DIR__ . '/../../../json/thesauri/cgi.json';
+            if (!file_exists($jsonPath)) {
+                throw new Exception('CGI keywords file not found');
+            }
+            $json = file_get_contents($jsonPath);
+            if ($json === false) {
+                throw new Exception('Error reading CGI keywords file');
+            }
+            header('Content-Type: application/json');
+            echo $json;
+        } catch (Exception $e) {
+            http_response_code(500);
+            echo json_encode(['error' => $e->getMessage()]);
+        }
+    }
+
+    /**
      * Updates the MSL Labs vocabulary by fetching and processing data, then saving it as JSON.
      *
      * @return void

--- a/api/v2/controllers/VocabController.php
+++ b/api/v2/controllers/VocabController.php
@@ -174,6 +174,71 @@ class VocabController
     }
 
     /**
+     * Fetches the CGI Simple Lithology vocabulary from the official RDF source
+     * and returns a hierarchical array formatted for jsTree.
+     *
+     * @return array Parsed CGI keywords tree
+     * @throws Exception If fetching or parsing the RDF data fails
+     */
+    public function fetchAndProcessCGIKeywords()
+    {
+        // Source URL of the CGI Simple Lithology vocabulary
+        $url = 'https://geosciml.org/resource/vocabulary/cgi/2016/simplelithology.rdf';
+
+        // Register RDF namespaces
+        RdfNamespace::set('skos', 'http://www.w3.org/2004/02/skos/core#');
+        RdfNamespace::set('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+
+        // Load RDF data
+        $graph = new Graph($url);
+        $graph->load();
+
+        $keywordMap = [];
+
+        // Iterate through all SKOS concepts
+        foreach ($graph->allOfType('skos:Concept') as $concept) {
+            $id = $concept->getUri();
+            $prefLabel = (string) $concept->get('skos:prefLabel');
+            $definition = (string) $concept->get('skos:definition');
+
+            $keywordMap[$id] = [
+                'id' => $id,
+                'text' => $prefLabel,
+                'language' => 'en',
+                'scheme' => 'CGI Simple Lithology',
+                'schemeURI' => 'https://geosciml.org/resource/vocabulary/cgi/2016/simplelithology',
+                'description' => $definition,
+                'children' => []
+            ];
+        }
+
+        // Build hierarchy with compound_material as the root node
+        $rootId = 'http://resource.geosciml.org/classifier/cgi/lithology/compound_material';
+        foreach ($graph->allOfType('skos:Concept') as $concept) {
+            $id = $concept->getUri();
+            if ($id === $rootId) {
+                continue; // Skip the root element
+            }
+            $broader = $concept->all('skos:broader');
+            if (empty($broader)) {
+                // Concepts without a broader term become children of the root
+                $keywordMap[$rootId]['children'][] = &$keywordMap[$id];
+            } else {
+                foreach ($broader as $parent) {
+                    $parentId = $parent->getUri();
+                    if (isset($keywordMap[$parentId])) {
+                        $keywordMap[$parentId]['children'][] = &$keywordMap[$id];
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Return only the root element
+        return [$keywordMap[$rootId]];
+    }
+
+    /**
      * Gets the latest version number for the combined vocabulary file.
      *
      * @param string $baseUrl The base URL for vocabularies.
@@ -373,6 +438,48 @@ class VocabController
             }
             header('Content-Type: application/json');
             echo $json;
+        } catch (Exception $e) {
+            http_response_code(500);
+            echo json_encode(['error' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Updates the CGI Simple Lithology keywords by fetching the latest RDF and
+     * storing it as JSON for use by the frontend.
+     *
+     * @return void
+     */
+    public function updateCGIKeywords()
+    {
+        // Validate API key before processing request
+        if (!$this->validateApiKey()) {
+            return;
+        }
+
+        try {
+            $keywords = $this->fetchAndProcessCGIKeywords();
+
+            $jsonDir = __DIR__ . '/../../../json/thesauri/';
+            if (!file_exists($jsonDir)) {
+                mkdir($jsonDir, 0755, true);
+            }
+
+            $result = file_put_contents(
+                $jsonDir . 'cgi.json',
+                json_encode($keywords, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+
+            if ($result === false) {
+                throw new Exception('Error saving JSON file: ' . error_get_last()['message']);
+            }
+
+            header('Content-Type: application/json');
+            echo json_encode([
+                'message' => 'CGI keywords successfully updated',
+                'timestamp' => date('c')
+            ]);
+
         } catch (Exception $e) {
             http_response_code(500);
             echo json_encode(['error' => $e->getMessage()]);

--- a/api/v2/docs/swagger.yaml
+++ b/api/v2/docs/swagger.yaml
@@ -198,6 +198,43 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /update/vocabs/cgi:
+    get:
+      tags:
+        - update
+      summary: Update CGI Simple Lithology keywords
+      description: Fetches the latest CGI Simple Lithology vocabulary and stores it as JSON.
+      operationId: updateCGIKeywords
+      responses:
+        "200":
+          description: CGI keywords successfully updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "CGI keywords successfully updated"
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: "2025-01-19T08:45:22Z"
+                required:
+                  - message
+                  - timestamp
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized - Invalid or missing API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /update/crossref:
     get:
       tags:

--- a/api/v2/docs/swagger.yaml
+++ b/api/v2/docs/swagger.yaml
@@ -297,6 +297,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /vocabs/cgi:
+    get:
+      tags:
+        - vocabularies
+      security: []
+      summary: Get CGI Simple Lithology keywords
+      description: Retrieve the CGI Simple Lithology vocabulary already prepared for use with jsTree
+      operationId: getCGIKeywords
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VocabularyTree"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /vocabs/freekeywords/all:
     get:
       tags:

--- a/api/v2/routes/api.php
+++ b/api/v2/routes/api.php
@@ -20,6 +20,7 @@ return [
     ['GET', '/update/vocabs/msl', [new VocabController(), 'getMslVocab']],
     ['GET', '/update/timezones', [new VocabController(), 'updateTimezones']],
     ['GET', '/update/vocabs/gcmd', [new VocabController(), 'updateGcmdVocabs']],
+    ['GET', '/update/vocabs/cgi', [new VocabController(), 'updateCGIKeywords']],
     ['GET', '/update/ror', [new VocabController(), 'getRorAffiliations']],
     ['GET', '/update/crossref', [new VocabController(), 'getCrossref']],
 

--- a/api/v2/routes/api.php
+++ b/api/v2/routes/api.php
@@ -25,6 +25,7 @@ return [
 
     // Vocabulary retrieval endpoints
     ['GET', '/vocabs/sciencekeywords', [new VocabController(), 'getGcmdScienceKeywords']],
+    ['GET', '/vocabs/cgi', [new VocabController(), 'getCGIKeywords']],
     ['GET', '/vocabs/roles[/{type}]', [new VocabController(), 'getRoles']],
     ['GET', '/vocabs/relations', [new VocabController(), 'getRelations']],
     ['GET', '/vocabs/licenses/all', [new VocabController(), 'getAllLicenses']],


### PR DESCRIPTION
This pull request moves functionality to retrieve CGI Simple Lithology keywords and integrates it into the APIv2. The most important changes include adding a new method to handle the retrieval of these keywords, updating the API routes, and documenting the new endpoint in the Swagger specification.

Fixes #61 

## Changes
### New functionality for CGI Simple Lithology keywords
* [`api/v2/controllers/VocabController.php`](diffhunk://#diff-b9667eda042481bdf5e70cbb02cd5b4e00a9ccc21b5ea5de5e8437c68bff2fa8R358-R381): Added the `getCGIKeywords()` method to retrieve CGI Simple Lithology keywords from a local JSON file, handle errors gracefully, and return the data as JSON.

### API integration
* [`api/v2/routes/api.php`](diffhunk://#diff-df40779a952ef6bed2a68ca3827ca48b8bdf44ff2e94754b4f04162da7693282R28): Added a new route `/vocabs/cgi` to map the `getCGIKeywords()` method for handling requests to retrieve CGI Simple Lithology keywords.

### Documentation updates
* [`api/v2/docs/swagger.yaml`](diffhunk://#diff-9bbd208fb9ba03e82da355248278131ebdd2c508176e8cde430485cbc464e421R300-R320): Added documentation for the new `/vocabs/cgi` endpoint, including its description, expected responses, and associated schema references.

## Notes for Reviewer
[Beschreibung der notwendigen Testschritte]

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [ ] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [ ] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
[Welche Probleme mit niedrigerer Priorität bestehen noch?]
