### PR TITLE
Fix: save and submit buttons working propperly

### DIFF
--- a/api/v2/controllers/DatasetController.php
+++ b/api/v2/controllers/DatasetController.php
@@ -1096,14 +1096,14 @@ class DatasetController
 
 
         $outputFile = $this->generate_xml_path($id);
-
+        // It saves the in-memory XML to a file on the disk.
         if (!@$dom->save($outputFile)) {
             throw new Exception("Konnte XML-Datei nicht speichern: " . error_get_last()['message']);
         }
 
         // DB-Verbindung schließen
         $stmt->close();
-
+        // Return the XML as a string (additionally to saving it)
         return $xml->asXML();
     }
 
@@ -1337,6 +1337,20 @@ XML;
         }
         exit();
     }
+    /**
+     * this public function is used as an endpoint to get the XML in all formats. So called envelope.
+     * Generates a transformed XML string for a given format without downloading it.
+     *
+     * @param mysqli $connection The database connection.
+     * @param int $id The ID of the resource.
+     */
+    public function envelopeXmlAsString($connection, $id)
+    {
+        // Use the existing private function, but tell it NOT to download.
+        // The 'false' at the end is the key.
+        $vars = ['id' => $id];
+        return $this->handleExportAll($vars, false);
+    }    
     /**
          * Exports the base XML for a resource as a file download.
          *

--- a/save/save_data.php
+++ b/save/save_data.php
@@ -75,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
     // Logic in these lines is to enable XML save
     // After the resource information is written to the db,
-    // nothing transfers the information to xml format.
+    // Currently, nothing transfers the information to xml format.
     // in the meanwhile, if this lines do work,
     // the xml file will be generated on the run
     require_once '../api/v2/controllers/DatasetController.php';
@@ -92,20 +92,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
         $base_url = $protocol . $_SERVER['HTTP_HOST'];
-        $project_path = rtrim(dirname(dirname($_SERVER['PHP_SELF'])), '/\\'); // More robust path trimming
+        $project_path = rtrim(dirname(dirname($_SERVER['PHP_SELF'])), '/\\'); // Ensure no trailing slashes
         $url = $base_url . $project_path . "/api/v2/dataset/export/" . $resource_id . "/all";
 
         // readfile() returns the number of bytes read, or false on failure.
         $bytesRead = @readfile($url);
 
         if ($bytesRead === false) {
-            error_log("save_data.php: readfile from URL failed. Falling back to direct generation for resource ID: $resource_id");
+            error_log("save_data.php: readfile from URL failed. URL: $url . Falling back to direct generation for resource ID: $resource_id");
 
             try {
                 // The controller is already included, so we can use it.
                 $datasetController = new DatasetController();
                 // Generate XML directly in-memory
-                $xmlString = $datasetController->getResourceAsXml($connection, $resource_id);
+                $xmlString = $datasetController->envelopeXmlAsString($connection, $resource_id);
 
                 if ($xmlString) {
                     echo $xmlString;

--- a/save/save_data.php
+++ b/save/save_data.php
@@ -72,35 +72,54 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         saveGGMsProperties($connection, $_POST, $resource_id);
     }
 
-
-require_once __DIR__ . '/../api/v2/controllers/DatasetController.php';
-$datasetController = new DatasetController();
-$xmlString = $datasetController->getResourceAsXml($connection, $resource_id);
-
- // Handle file download if requested
-if (isset($_POST['filename'])) {
-    $filename = preg_replace('/[^a-zA-Z0-9_-]/', '_', $_POST['filename']) . '.xml';
-
-    header('Content-Type: application/xml');
-    header('Content-Disposition: attachment; filename="' . $filename . '"');
-
-    // Build API URL and local file path
-    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
-    $base_url = $protocol . $_SERVER['HTTP_HOST'];
-    $project_path = dirname(dirname($_SERVER['PHP_SELF']));
-    $url = $base_url . $project_path . "/api/v2/dataset/export/" . $resource_id . "/all";
-    $localpath = "/var/www/html/xml/resource_" . $resource_id . ".xml";
-
-    // Try to fetch via HTTP first
-    $data = @file_get_contents($url);
-    if ($data !== false) {
-        echo $data;
-    } elseif (file_exists($localpath)) {
-        readfile($localpath);
-    } else {
-        http_response_code(404);
-        echo "File not found (neither remote nor local).";
+    try {
+    // Logic in these lines is to enable XML save
+    // After the resource information is written to the db,
+    // nothing transfers the information to xml format.
+    // in the meanwhile, if this lines do work,
+    // the xml file will be generated on the run
+    require_once '../api/v2/controllers/DatasetController.php';
+    $datasetController = new DatasetController();
+    } catch (Exception $e) {
+        error_log("Error accessing DatasetController: function getResourceAsXml is not available. Exception: " . $e->getMessage());
     }
-    exit();
-    }
+    // Handle file download if requested
+    if (isset($_POST['filename'])) {
+        $filename = preg_replace('/[^a-zA-Z0-9_-]/', '_', $_POST['filename']) . '.xml';
+
+        header('Content-Type: application/xml');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+        $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
+        $base_url = $protocol . $_SERVER['HTTP_HOST'];
+        $project_path = rtrim(dirname(dirname($_SERVER['PHP_SELF'])), '/\\'); // More robust path trimming
+        $url = $base_url . $project_path . "/api/v2/dataset/export/" . $resource_id . "/all";
+
+        // readfile() returns the number of bytes read, or false on failure.
+        $bytesRead = @readfile($url);
+
+        if ($bytesRead === false) {
+            error_log("save_data.php: readfile from URL failed. Falling back to direct generation for resource ID: $resource_id");
+
+            try {
+                // The controller is already included, so we can use it.
+                $datasetController = new DatasetController();
+                // Generate XML directly in-memory
+                $xmlString = $datasetController->getResourceAsXml($connection, $resource_id);
+
+                if ($xmlString) {
+                    echo $xmlString;
+                } else {
+                    // This part of the code will only be reached if both methods fail.
+                    http_response_code(500);
+                    echo "Error: Could not retrieve or generate XML file.";
+                }
+            } catch (Exception $e) {
+                error_log("Error in save_data.php fallback: " . $e->getMessage());
+                http_response_code(500);
+                echo "Error: XML generation inside save_data failed";
+            }
+        }
+        exit();
+    }    
 }


### PR DESCRIPTION
Es geht um save and submit Funktionalitäten. Die hier genutzte Methode ist diese: debug extistierende Lösung + eine neue Lösung implementieren für den Fall, dass das nicht gut functioniert. 

Die existierende Logik ist API Endpunkt zu benutzen. Das ist kompakt und nutzt null Memory, aber das kann scwierig für ein Container sein (wie zbs. bei mir lokal), zu sich selbst ein HTTP request zu senden.

Die neue Logik spielt eine Rolle nur dann, wann die existierende nicht funktioniert. Die Idee ist DatasetController zu nutzen, um envelope XMLs on-the-fly oder in-memory zu produzieren. 

 

## Changes
Diese 2-Methode doppelgesicherte Strategie ist für save_data.php und send_xml_file.php implementiert
Neue public Method ist in DatasetController implementiert. Das "publiziert" HandleExportAll Method.

**Logging** is corrected! error log is available in Docker:
`docker logs container-name`
zbs.
`docker logs elmo-web-1`

## Notes for Reviewer
Ich würde sehr gerne submit Taste beim Test-server testen und sehen, ob die Emails mit richtigen Daten die richtige Email Adressen erreichen.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
[Welche Probleme mit niedrigerer Priorität bestehen noch?]
