### PR TITLE
Chore: Moved jQuery from CDN to npm installation and unit tests for automcomplete.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The following third-party dependencies are included in header.php and footer.htm
   For the event handlers in JavaScript and to simplify the JavaScript code.
 - [jQuery UI 1.14.1](https://github.com/jquery/jquery-ui/releases)<br>
   Extends jQuery with the autocomplete function that we currently use for the affiliation fields.
-- [Tagify 4.33.2](https://github.com/yairEO/tagify/releases)<br>
+- [Tagify 4](https://github.com/yairEO/tagify/releases)<br>
   Is used for the Thesaurus Keywords field, the entry of multiple affiliations and free keywords.
 - [jsTree 3.3.17](https://github.com/vakata/jstree/releases)<br>
   Is used to display the thesauri as a hierarchical tree structure.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The following third-party dependencies are included in header.php and footer.htm
   For the design, responsiveness and dark mode.
 - [Bootstrap Icons 1.11.3](https://github.com/twbs/icons/releases)<br>
   For the icons used.
-- [jQuery 3.7.1](https://github.com/jquery/jquery/releases)<br>
+- [jQuery 3](https://github.com/jquery/jquery/releases)<br>
   For the event handlers in JavaScript and to simplify the JavaScript code.
 - [jQuery UI 1.14.1](https://github.com/jquery/jquery-ui/releases)<br>
   Extends jQuery with the autocomplete function that we currently use for the affiliation fields.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The following third-party dependencies are included in header.php and footer.htm
   For the icons used.
 - [jQuery 3](https://github.com/jquery/jquery/releases)<br>
   For the event handlers in JavaScript and to simplify the JavaScript code.
-- [jQuery UI 1.14.1](https://github.com/jquery/jquery-ui/releases)<br>
+- [jQuery UI 1](https://github.com/jquery/jquery-ui/releases)<br>
   Extends jQuery with the autocomplete function that we currently use for the affiliation fields.
 - [Tagify 4](https://github.com/yairEO/tagify/releases)<br>
   Is used for the Thesaurus Keywords field, the entry of multiple affiliations and free keywords.

--- a/doc/help.html
+++ b/doc/help.html
@@ -1190,9 +1190,7 @@ include_once "../settings.php";
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"></script>
     <!-- jQuery -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
-        integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="../node_modules/jquery/dist/jquery.min.js"></script>
     <!-- Custom jQuery Script -->
     <script src="helpMenu.js"></script>
 </body>

--- a/footer.html
+++ b/footer.html
@@ -33,9 +33,7 @@
   </div>
 </footer>
 <!-- jQuery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
-  integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
-  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="node_modules/jquery/dist/jquery.min.js"></script>
 <!-- jQuery UI -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.1/jquery-ui.min.js"
   integrity="sha512-MSOo1aY+3pXCOCdGAYoBZ6YGI0aragoQsg1mKKBHXCYPIWxamwOE7Drh+N5CPgGI5SA9IEKJiPjdfqWFWmZtRA=="

--- a/footer.html
+++ b/footer.html
@@ -35,9 +35,7 @@
 <!-- jQuery -->
 <script src="node_modules/jquery/dist/jquery.min.js"></script>
 <!-- jQuery UI -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.1/jquery-ui.min.js"
-  integrity="sha512-MSOo1aY+3pXCOCdGAYoBZ6YGI0aragoQsg1mKKBHXCYPIWxamwOE7Drh+N5CPgGI5SA9IEKJiPjdfqWFWmZtRA=="
-  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="node_modules/jquery-ui/dist/jquery-ui.min.js"></script>
 <!-- JavaScript-Dateien -->
 <!-- Language switch -->
 <script src="js/language.js"></script>

--- a/header.php
+++ b/header.php
@@ -20,7 +20,7 @@ sort($langCodes);
     href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css"
     integrity="sha512-dPXYcDub/aeb08c63jRq/k6GaKccl256JQy/AnOq7CAnEZ9FzSL9wSbcZkMp4R26vBsMLFYH4kQ67/bbV8XaCQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <!-- CDN for Tagify CSS -->
+  <!-- Local Tagify CSS -->
   <link href="node_modules\@yaireo\tagify\dist\tagify.css" rel="stylesheet" type="text/css" />
   <!-- CDN for jsTree CSS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.17/themes/default/style.min.css"

--- a/header.php
+++ b/header.php
@@ -13,10 +13,8 @@ sort($langCodes);
   <!-- CDN for Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <!-- CDN for jQuery UI CSS -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.14.1/themes/base/jquery-ui.min.css"
-    integrity="sha512-TFee0335YRJoyiqz8hA8KV3P0tXa5CpRBSoM0Wnkn7JoJx1kaq1yXL/rb8YFpWXkMOjRcv5txv+C6UluttluCQ=="
-    crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <!-- Local jQuery UI CSS -->
+  <link rel="stylesheet" href="node_modules/jquery-ui/dist/themes/base/jquery-ui.min.css" />
   <!-- CDN for Bootstrap Icons CSS -->
   <link rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css"

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@ sort($langCodes);
     integrity="sha512-dPXYcDub/aeb08c63jRq/k6GaKccl256JQy/AnOq7CAnEZ9FzSL9wSbcZkMp4R26vBsMLFYH4kQ67/bbV8XaCQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
   <!-- Local Tagify CSS -->
-  <link href="node_modules\@yaireo\tagify\dist\tagify.css" rel="stylesheet" type="text/css" />
+  <link href="node_modules/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
   <!-- CDN for jsTree CSS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.17/themes/default/style.min.css"
     integrity="sha512-A5OJVuNqxRragmJeYTW19bnw9M2WyxoshScX/rGTgZYj5hRXuqwZ+1AVn2d6wYTZPzPXxDeAGlae0XwTQdXjQA=="

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "dependencies": {
         "@yaireo/tagify": "^4.33.2",
-        "jquery": "^3.7.1"
+        "jquery": "^3.7.1",
+        "jquery-ui": "^1.14.1"
       },
       "devDependencies": {
         "jest": "^30.0.4",
@@ -3453,6 +3454,15 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
+    },
+    "node_modules/jquery-ui": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.14.1.tgz",
+      "integrity": "sha512-DhzsYH8VeIvOaxwi+B/2BCsFFT5EGjShdzOcm5DssWjtcpGWIMsn66rJciDA6jBruzNiLf1q0KvwMoX1uGNvnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": ">=1.12.0 <5.0.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@yaireo/tagify": "^4.33.2"
+        "@yaireo/tagify": "^4.33.2",
+        "jquery": "^3.7.1"
       },
       "devDependencies": {
         "jest": "^30.0.4",
@@ -3446,6 +3447,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@yaireo/tagify": "^4.33.2"
+    "@yaireo/tagify": "^4.33.2",
+    "jquery": "^3.7.1"
   },
   "devDependencies": {
     "jest": "^30.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "@yaireo/tagify": "^4.33.2",
-    "jquery": "^3.7.1"
+    "jquery": "^3.7.1",
+    "jquery-ui": "^1.14.1"
   },
   "devDependencies": {
     "jest": "^30.0.4",

--- a/tests/js/affiliations.test.js
+++ b/tests/js/affiliations.test.js
@@ -1,25 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-// Simple jQuery stub used in the tests
-function createJQuery() {
-  const $ = (selector) => {
-    if (selector === document) {
-      return { ready: (fn) => fn() };
-    }
-    const element = document.querySelector(selector);
-    return {
-      length: element ? 1 : 0,
-      0: element,
-      val: (v) => {
-        if (v === undefined) return element.value;
-        element.value = v;
-      }
-    };
-  };
-  $.getJSON = jest.fn((file, cb) => cb([]));
-  return $;
-}
+let $;
 
 class MockTagify {
   constructor(el, options) {
@@ -74,7 +56,12 @@ describe('affiliations.js', () => {
       <input id="contact-person-field" />
     `;
 
-    global.$ = createJQuery();
+    $ = require('jquery');
+    $.getJSON = jest.fn((file, cb) => cb([]));
+    global.$ = $;
+    global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
     global.Tagify = MockTagify;
     global.translations = { general: { affiliation: 'affiliation' } };
 

--- a/tests/js/autocomplete.test.js
+++ b/tests/js/autocomplete.test.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const path = require('path');
+
+// Simple Tagify stub from existing tests
+class MockTagify {
+  constructor(el, options = {}) {
+    this.el = el;
+    this.settings = options;
+    this.whitelist = options.whitelist || [];
+    this.value = [];
+    this.DOM = { input: { style: { width: '' } } };
+    this.dropdown = { hide: jest.fn() };
+  }
+  addTags(items) {
+    const arr = Array.isArray(items) ? items : [items];
+    arr.forEach(item => {
+      if (typeof item === 'string') {
+        this.value.push({ value: item });
+      } else {
+        this.value.push(item);
+      }
+    });
+  }
+  removeAllTags() {
+    this.value = [];
+  }
+}
+
+const flushPromises = () => new Promise(res => setTimeout(res, 0));
+
+describe('autocomplete.js', () => {
+  let $;
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <select id="input-rights-license">
+        <option>MIT License</option>
+        <option>Apache License 2.0</option>
+        <option>GPL</option>
+      </select>
+      <select id="input-resourceinformation-resourcetype">
+        <option value="Article">Article</option>
+        <option value="Software">Software</option>
+      </select>
+      <div id="group-author">
+        <div data-creator-row>
+          <input name="orcids[]" />
+          <input name="familynames[]" />
+          <input name="givennames[]" />
+          <input id="input-author-affiliation" />
+          <input id="input-author-rorid" />
+        </div>
+      </div>
+      <div id="group-contributorperson">
+        <div contributor-person-row>
+          <input name="cbORCID[]" />
+          <input name="cbPersonLastname[]" />
+          <input name="cbPersonFirstname[]" />
+          <input id="input-contributorpersons-affiliation" />
+          <input id="input-contributor-personrorid" />
+        </div>
+      </div>
+    `;
+
+    $ = require('jquery');
+    global.$ = $;
+    global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
+    global.Tagify = MockTagify;
+    global.fetch = jest.fn();
+
+    const script = fs.readFileSync(path.resolve(__dirname, '../../js/autocomplete.js'), 'utf8');
+    window.eval(script);
+    await flushPromises();
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('license options filtered based on resource type', () => {
+    $('#input-resourceinformation-resourcetype').val('Software').trigger('change');
+    let options = $('#input-rights-license option').map((i, el) => $(el).text()).get();
+    expect(options).toEqual(['MIT License', 'Apache License 2.0']);
+
+    $('#input-resourceinformation-resourcetype').val('Article').trigger('change');
+    options = $('#input-rights-license option').map((i, el) => $(el).text()).get();
+    expect(options).toEqual(['MIT License', 'Apache License 2.0', 'GPL']);
+  });
+
+  test('isCurrentAffiliation utility', () => {
+    expect(window.isCurrentAffiliation({})).toBe(true);
+    expect(window.isCurrentAffiliation({ 'end-date': { year: 2020 } })).toBe(false);
+  });
+
+  test('author ORCID blur fills data', async () => {
+    const data = {
+      person: {
+        name: {
+          'family-name': { value: 'Doe' },
+          'given-names': { value: 'John' }
+        }
+      },
+      'activities-summary': {
+        employments: {
+          'affiliation-group': [
+            { summaries: [ { 'employment-summary': { organization: { name: 'Uni A', 'disambiguated-organization': { 'disambiguation-source': 'ROR', 'disambiguated-organization-identifier': '123' } } } } ] }
+          ]
+        }
+      }
+    };
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve(data) });
+
+    const affInput = document.getElementById('input-author-affiliation');
+    affInput.tagify = new MockTagify(affInput, {});
+
+    const orcidInput = $('#group-author input[name="orcids[]"]');
+    orcidInput.val('0000-0000-0000-0000').trigger('blur');
+    await flushPromises();
+
+    expect(fetch).toHaveBeenCalled();
+    expect($('#group-author input[name="familynames[]"]').val()).toBe('Doe');
+    expect($('#group-author input[name="givennames[]"]').val()).toBe('John');
+    expect(affInput.tagify.value[0].value).toBe('Uni A');
+    expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/123');
+  });
+
+  test('contributor ORCID blur fills data', async () => {
+    const data = {
+      person: {
+        name: {
+          'family-name': { value: 'Smith' },
+          'given-names': { value: 'Anna' }
+        }
+      },
+      'activities-summary': {
+        employments: {
+          'affiliation-group': [
+            { summaries: [ { 'employment-summary': { organization: { name: 'Lab B', 'disambiguated-organization': { 'disambiguation-source': 'ROR', 'disambiguated-organization-identifier': 'XYZ' } } } } ] }
+          ]
+        }
+      }
+    };
+    fetch.mockResolvedValueOnce({ json: () => Promise.resolve(data) });
+
+    const affInput = document.getElementById('input-contributorpersons-affiliation');
+    affInput.tagify = new MockTagify(affInput, {});
+
+    const orcidInput = $('#group-contributorperson input[name="cbORCID[]"]');
+    orcidInput.val('1111-2222-3333-4444').trigger('blur');
+    await flushPromises();
+
+    expect($('#group-contributorperson input[name="cbPersonLastname[]"]').val()).toBe('Smith');
+    expect($('#group-contributorperson input[name="cbPersonFirstname[]"]').val()).toBe('Anna');
+    expect(affInput.tagify.value[0].value).toBe('Lab B');
+    expect(document.getElementById('input-contributor-personrorid').value).toBe('https://ror.org/XYZ');
+  });
+});


### PR DESCRIPTION
This pull request introduces several changes aimed at improving dependency management, transitioning to local libraries, and enhancing unit testing. The most significant updates include replacing CDN-based dependencies with locally managed ones, adding new dependencies to `package.json`, and updating tests to use the imported `jQuery` library instead of custom stubs.

## Changes
### Dependency Management Updates
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L211-R215): Updated third-party dependency descriptions to reflect the transition from specific version numbers to general library names (e.g., `jQuery 3.7.1` to `jQuery 3`).
* `header.php`, `footer.html`, and `doc/help.html`: Replaced CDN references for `jQuery`, `jQuery UI`, and `Tagify` with local paths pointing to `node_modules`. This improves maintainability and reduces reliance on external CDNs. [[1]](diffhunk://#diff-e7f789e333fc7ce27ae3d6999cca0b78637e8b96c734dea9aedb855b278b7eb9L16-R23) [[2]](diffhunk://#diff-86e633fe0493da5e3a927455882c9457e09813c83b66900a19765ee3c8b0ed22L36-R38) [[3]](diffhunk://#diff-52e769990480a2cdd9a36840d023db9c394fd95bdbfa70b4255b4e345a4ee422L1193-R1193)

### Dependency Additions
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R5): Added `jquery` and `jquery-ui` as dependencies to ensure local availability of these libraries.

### Unit Test Updates
* [`tests/js/affiliations.test.js`](diffhunk://#diff-e6444cfd5ecccf5b63e0d0f08e16e1b508411507a9b826c58e197073dec183e4L4-R4): Replaced the custom `jQuery` stub with the actual `jQuery` library imported from `node_modules`. This aligns tests with the updated dependency management approach. [[1]](diffhunk://#diff-e6444cfd5ecccf5b63e0d0f08e16e1b508411507a9b826c58e197073dec183e4L4-R4) [[2]](diffhunk://#diff-e6444cfd5ecccf5b63e0d0f08e16e1b508411507a9b826c58e197073dec183e4L77-R64)
* [`tests/js/autocomplete.test.js`](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eR1-R159): Added new unit tests for `autocomplete.js`, including tests for filtering license options, validating affiliations, and populating author/contributor data based on ORCID inputs. These tests utilize the imported `jQuery` library and a mock `Tagify` class for simulating tag input behavior.

## Notes for Reviewer
- I had already taken the first step toward installing JavaScript dependencies locally with Tagify. This is the second step in that direction and does the same with jQuery and jQuery UI.
- I deliberately did not update the JS dependencies that were already installed locally. This should be done in a later PR so that errors in both tasks can be clearly separated.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
