### PR TITLE
Feature: New API endpoint for language of dataset options

### DIFF
--- a/api/v2/controllers/VocabController.php
+++ b/api/v2/controllers/VocabController.php
@@ -1464,5 +1464,38 @@ class VocabController
             echo json_encode(['error' => $e->getMessage()]);
         }
     }
-}
 
+    /**
+     * Retrieves all languages from the database
+     *
+     * @return void Outputs JSON response directly
+     */
+    public function getLanguages(): void
+    {
+        try {
+            global $connection;
+            $stmt = $connection->prepare('SELECT language_id as id, code, name FROM Language ORDER BY name');
+
+            if (!$stmt) {
+                throw new Exception("Failed to prepare statement: " . $connection->error);
+            }
+
+            $stmt->execute();
+            $result = $stmt->get_result();
+
+            $languages = [];
+            while ($row = $result->fetch_assoc()) {
+                $languages[] = $row;
+            }
+
+            header('Content-Type: application/json');
+            echo json_encode($languages);
+
+        } catch (Exception $e) {
+            error_log("API Error in getLanguages: " . $e->getMessage());
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => $e->getMessage()]);
+        }
+    }
+}

--- a/api/v2/docs/swagger.yaml
+++ b/api/v2/docs/swagger.yaml
@@ -589,6 +589,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /vocabs/languages:
+    get:
+      tags:
+        - vocabularies
+      security: []
+      summary: Get languages
+      description: Retrieve all available languages
+      operationId: getLanguages
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Language"
+        "404":
+          description: No languages found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /validation/patterns/{type}:
     get:
       tags:
@@ -1166,3 +1195,22 @@ components:
       required:
         - id
         - resource_type_general
+    Language:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique identifier of the language
+          example: 1
+        code:
+          type: string
+          description: ISO 639-1 code of the language
+          example: en
+        name:
+          type: string
+          description: Name of the language
+          example: English
+      required:
+        - id
+        - code
+        - name

--- a/api/v2/routes/api.php
+++ b/api/v2/routes/api.php
@@ -35,6 +35,7 @@ return [
     ['GET', '/vocabs/freekeywords/curated', [new VocabController(), 'getCuratedFreeKeywords']],
     ['GET', '/vocabs/freekeywords/uncurated', [new VocabController(), 'getUncuratedFreeKeywords']],
     ['GET', '/vocabs/resourcetypes', [new VocabController(), 'getResourceTypes']],
+    ['GET', '/vocabs/languages', [new VocabController(), 'getLanguages']],
 
     // Vocabulary retrieval for ICGEM implementation
     ['GET', '/vocabs/icgemformats', [new VocabController(), 'getICGEMFileFormats']],

--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -95,7 +95,7 @@
             <div class="input-group has-validation">
               <div class="form-floating">
                 <select class="form-select" id="input-resourceinformation-language" name="language" required>
-                  <?php echo $optionlanguage; ?>
+                  <option disabled selected hidden value="" data-translate="general.choose"></option>
                 </select>
                 <label for="input-resourceinformation-language">
                   <span data-translate="resourceInfo.datasetLanguage"></span><span class="red-star">*</span>

--- a/index.php
+++ b/index.php
@@ -41,13 +41,6 @@ function generateOptions($conn, $query, $idField, $nameField)
 }
 
 // Generate dropdown options
-$optionlanguage = generateOptions(
-    $connection,
-    "SELECT language_id, name FROM Language",
-    "language_id",
-    "name"
-);
-
 $optiontitle_type = generateOptions(
     $connection,
     "SELECT title_type_id, name FROM Title_Type",

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -93,6 +93,30 @@ async function createLicenseMapping() {
 }
 
 /**
+ * Creates a language mapping from API data
+ * @returns {Promise<Object>} A promise that resolves to a code->id mapping
+ */
+async function createLanguageMapping() {
+  try {
+    const response = await $.getJSON("./api/v2/vocabs/languages");
+    const mapping = {};
+
+    response.forEach((lang) => {
+      mapping[lang.code.toLowerCase()] = lang.id.toString();
+    });
+
+    return mapping;
+  } catch (error) {
+    console.error("Error creating language mapping:", error);
+    return {
+      en: "1",
+      de: "2",
+      fr: "3",
+    };
+  }
+}
+
+/**
  * Maps title type to select option value
  * @param {string} titleType - The type of the title from XML
  * @returns {string} The corresponding select option value
@@ -1121,8 +1145,10 @@ async function loadXmlToForm(xmlDoc) {
       labData = [];
     }
   }
-  // Erstelle das License-Mapping zuerst
+
+  // Erstelle das License- und Language-Mapping zuerst
   const licenseMapping = await createLicenseMapping();
+  const languageMapping = await createLanguageMapping();
 
   // Definiere das komplette XML_MAPPING mit dem erstellten licenseMapping
   const XML_MAPPING = {
@@ -1145,13 +1171,7 @@ async function loadXmlToForm(xmlDoc) {
       selector: "#input-resourceinformation-language",
       attribute: "textContent",
       transform: (value) => {
-        // Map language codes to database IDs
-        const languageMap = {
-          en: "1", // Assuming English has ID 1
-          de: "2", // Assuming German has ID 2
-          fr: "3", // Assuming French has ID 3
-        };
-        return languageMap[value.toLowerCase()] || "1"; // Default to English if not found
+        return languageMapping[value.toLowerCase()] || "1";
       },
     },
     // Rights

--- a/js/select.js
+++ b/js/select.js
@@ -143,6 +143,7 @@ async function initializeTimezoneDropdown(dropdownSelector = '#input-stc-timezon
 $(document).ready(function () {
   initializeTimezoneDropdown();
   setupResourceTypeDropdown();
+  setupLanguageDropdown();
 
   function setupResourceTypeDropdown() {
     const select = $("#input-resourceinformation-resourcetype");
@@ -191,6 +192,57 @@ $(document).ready(function () {
       },
       complete: function () {
         select.prop('disabled', false).trigger("change");
+      },
+    });
+  }
+
+  function setupLanguageDropdown() {
+    const select = $("#input-resourceinformation-language");
+    if (select.length === 0) return;
+
+    select.prop('disabled', true).empty().append(
+      $("<option>", {
+        value: "",
+        text: "Loading...",
+      })
+    );
+
+    $.ajax({
+      url: "api/v2/vocabs/languages",
+      method: "GET",
+      dataType: "json",
+      success: function (data) {
+        select.empty().append(
+          $("<option>", {
+            value: "",
+            text: "Choose...",
+            "data-translate": "general.choose",
+          })
+        );
+
+        if (Array.isArray(data)) {
+          data.forEach(function (lang) {
+            select.append(
+              $("<option>", {
+                value: lang.id,
+                text: lang.name,
+                title: lang.code,
+              })
+            );
+          });
+        }
+      },
+      error: function (jqXHR, textStatus, errorThrown) {
+        console.error("Error loading languages:", textStatus, errorThrown);
+        select.empty().append(
+          $("<option>", {
+            value: "",
+            text: "Error loading data",
+          })
+        );
+      },
+      complete: function () {
+        select.prop('disabled', false);
       },
     });
   }

--- a/js/select.js
+++ b/js/select.js
@@ -140,112 +140,118 @@ async function initializeTimezoneDropdown(dropdownSelector = '#input-stc-timezon
  * This script handles the setup and initialization of various dropdowns, event listeners, and autocomplete functions for the metadata editor.
  */
 
+// Dropdown helper functions exposed globally so tests can invoke them
+function setupResourceTypeDropdown() {
+  const select = $("#input-resourceinformation-resourcetype");
+  if (select.length === 0) return;
+
+  select.prop('disabled', true).empty().append(
+    $("<option>", {
+      value: "",
+      text: "Loading...",
+    })
+  );
+
+  $.ajax({
+    url: "api/v2/vocabs/resourcetypes",
+    method: "GET",
+    dataType: "json",
+    success: function (data) {
+      select.empty().append(
+        $("<option>", {
+          value: "",
+          text: "Choose...",
+          "data-translate": "general.choose",
+        })
+      );
+
+      if (Array.isArray(data)) {
+        data.forEach(function (type) {
+          select.append(
+            $("<option>", {
+              value: type.id,
+              text: type.resource_type_general,
+              title: type.description,
+            })
+          );
+        });
+      }
+    },
+    error: function (jqXHR, textStatus, errorThrown) {
+      console.error("Error loading resource types:", textStatus, errorThrown);
+      select.empty().append(
+        $("<option>", {
+          value: "",
+          text: "Error loading data",
+        })
+      );
+    },
+    complete: function () {
+      select.prop('disabled', false).trigger("change");
+    },
+  });
+}
+
+function setupLanguageDropdown() {
+  const select = $("#input-resourceinformation-language");
+  if (select.length === 0) return;
+
+  select.prop('disabled', true).empty().append(
+    $("<option>", {
+      value: "",
+      text: "Loading...",
+    })
+  );
+
+  $.ajax({
+    url: "api/v2/vocabs/languages",
+    method: "GET",
+    dataType: "json",
+    success: function (data) {
+      select.empty().append(
+        $("<option>", {
+          value: "",
+          text: "Choose...",
+          "data-translate": "general.choose",
+        })
+      );
+
+      if (Array.isArray(data)) {
+        data.forEach(function (lang) {
+          select.append(
+            $("<option>", {
+              value: lang.id,
+              text: lang.name,
+              title: lang.code,
+            })
+          );
+        });
+      }
+    },
+    error: function (jqXHR, textStatus, errorThrown) {
+      console.error("Error loading languages:", textStatus, errorThrown);
+      select.empty().append(
+        $("<option>", {
+          value: "",
+          text: "Error loading data",
+        })
+      );
+    },
+    complete: function () {
+      select.prop('disabled', false);
+    },
+  });
+}
+
+// Make functions available globally (important for tests)
+window.setupLanguageDropdown = setupLanguageDropdown;
+window.setupResourceTypeDropdown = setupResourceTypeDropdown;
+
 $(document).ready(function () {
   initializeTimezoneDropdown();
   setupResourceTypeDropdown();
   setupLanguageDropdown();
 
-  function setupResourceTypeDropdown() {
-    const select = $("#input-resourceinformation-resourcetype");
-    if (select.length === 0) return;
-
-    select.prop('disabled', true).empty().append(
-      $("<option>", {
-        value: "",
-        text: "Loading...",
-      })
-    );
-
-    $.ajax({
-      url: "api/v2/vocabs/resourcetypes",
-      method: "GET",
-      dataType: "json",
-      success: function (data) {
-        select.empty().append(
-          $("<option>", {
-            value: "",
-            text: "Choose...",
-            "data-translate": "general.choose",
-          })
-        );
-
-        if (Array.isArray(data)) {
-          data.forEach(function (type) {
-            select.append(
-              $("<option>", {
-                value: type.id,
-                text: type.resource_type_general,
-                title: type.description,
-              })
-            );
-          });
-        }
-      },
-      error: function (jqXHR, textStatus, errorThrown) {
-        console.error("Error loading resource types:", textStatus, errorThrown);
-        select.empty().append(
-          $("<option>", {
-            value: "",
-            text: "Error loading data",
-          })
-        );
-      },
-      complete: function () {
-        select.prop('disabled', false).trigger("change");
-      },
-    });
-  }
-
-  function setupLanguageDropdown() {
-    const select = $("#input-resourceinformation-language");
-    if (select.length === 0) return;
-
-    select.prop('disabled', true).empty().append(
-      $("<option>", {
-        value: "",
-        text: "Loading...",
-      })
-    );
-
-    $.ajax({
-      url: "api/v2/vocabs/languages",
-      method: "GET",
-      dataType: "json",
-      success: function (data) {
-        select.empty().append(
-          $("<option>", {
-            value: "",
-            text: "Choose...",
-            "data-translate": "general.choose",
-          })
-        );
-
-        if (Array.isArray(data)) {
-          data.forEach(function (lang) {
-            select.append(
-              $("<option>", {
-                value: lang.id,
-                text: lang.name,
-                title: lang.code,
-              })
-            );
-          });
-        }
-      },
-      error: function (jqXHR, textStatus, errorThrown) {
-        console.error("Error loading languages:", textStatus, errorThrown);
-        select.empty().append(
-          $("<option>", {
-            value: "",
-            text: "Error loading data",
-          })
-        );
-      },
-      complete: function () {
-        select.prop('disabled', false);
-      },
-    });
-  }
 
   /**
   * Populates the select field with ID input-rights-license with options created via an API call.

--- a/tests/js/mappingXmlToInputFields.test.js
+++ b/tests/js/mappingXmlToInputFields.test.js
@@ -112,6 +112,24 @@ describe("mappingXmlToInputFields helpers", () => {
     expect(fallback["Apache-2.0"]).toBe("5");
   });
 
+  test("createLanguageMapping resolves API data and handles errors", async () => {
+    const getJSON = jest.fn(() => Promise.resolve([
+      { id: 1, code: "en", name: "English" },
+      { id: 2, code: "de", name: "German" },
+    ]));
+    const ctx = loadMappingModule({ $: { getJSON } });
+    const result = await ctx.createLanguageMapping();
+    expect(getJSON).toHaveBeenCalled();
+    expect(result).toEqual({ en: "1", de: "2" });
+
+    const failingGetJSON = jest.fn(() => Promise.reject(new Error("fail")));
+    const ctxFail = loadMappingModule({ $: { getJSON: failingGetJSON }, console: { ...console, error: jest.fn() } });
+    const fallback = await ctxFail.createLanguageMapping();
+    expect(failingGetJSON).toHaveBeenCalled();
+    expect(fallback.en).toBe("1");
+    expect(fallback.de).toBe("2");
+  });
+
   test("setLabDataInRow populates fields and triggers change", () => {
     document.body.innerHTML = `
       <div id="row">

--- a/tests/js/select.test.js
+++ b/tests/js/select.test.js
@@ -137,4 +137,33 @@ describe('select.js', () => {
     expect(select.val()).toBe('+00:00');
     Intl.DateTimeFormat = originalIntl;
   });
+
+  test('setupLanguageDropdown populates options from API', async () => {
+    const select = $('<select id="input-resourceinformation-language"></select>').appendTo(document.body);
+    $.ajax.mockImplementation(opts => {
+      opts.success([
+        { id: 1, code: 'en', name: 'English' },
+        { id: 2, code: 'de', name: 'German' },
+      ]);
+      if (opts.complete) opts.complete();
+      return { fail: jest.fn() };
+    });
+
+    await flushPromises();
+    window.setupLanguageDropdown();
+    const options = select.find('option').map((i,el)=>$(el).text()).get();
+    expect(options).toEqual(['Choose...','English','German']);
+    expect(select.prop('disabled')).toBe(false);
+  });
+
+  test('setupLanguageDropdown shows error on ajax failure', async () => {
+    const select = $('<select id="input-resourceinformation-language"></select>').appendTo(document.body);
+    $.ajax.mockImplementation(opts => { if(opts.error) opts.error(); if(opts.complete) opts.complete(); return { fail: jest.fn() }; });
+
+    await flushPromises();
+    window.setupLanguageDropdown();
+    const options = select.find('option').map((i,el)=>$(el).text()).get();
+    expect(options).toEqual(['Error loading data']);
+    expect(select.prop('disabled')).toBe(false);
+  });
 });

--- a/tests/js/select.test.js
+++ b/tests/js/select.test.js
@@ -6,6 +6,7 @@ const flushPromises = () => new Promise(res => setTimeout(res, 0));
 describe('select.js', () => {
   let $;
   beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     document.body.innerHTML = `
       <select id="input-relatedwork-identifiertype"></select>
       <select id="test-select"></select>
@@ -44,6 +45,7 @@ describe('select.js', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    console.error.mockRestore();
     jest.resetAllMocks();
   });
 


### PR DESCRIPTION
This pull request introduces functionality to retrieve and manage language data via an API, integrating it into both the backend and frontend systems. The changes include adding a new API endpoint, updating the frontend to dynamically populate language dropdowns, and adding corresponding tests to ensure reliability.

These changes improve the system's flexibility and maintainability by centralizing language data management and enhancing the user experience with dynamic dropdowns.

Closes #358 

## Changes
### Backend Updates
* **New API Endpoint for Languages**: Added a `getLanguages` method in `VocabController` to fetch language data from the database and return it as JSON.
* **API Documentation**: Updated `swagger.yaml` to document the new `/vocabs/languages` endpoint and defined a `Language` schema. [[1]](diffhunk://#diff-9bbd208fb9ba03e82da355248278131ebdd2c508176e8cde430485cbc464e421R592-R620) [[2]](diffhunk://#diff-9bbd208fb9ba03e82da355248278131ebdd2c508176e8cde430485cbc464e421R1198-R1216)
* **Routing**: Added a route for the `/vocabs/languages` endpoint in `api.php`.

### Frontend Updates
* **Dynamic Language Dropdown**: Implemented `setupLanguageDropdown` in `js/select.js` to populate the language dropdown using the new API. Added error handling for API failures.
* **XML Mapping Integration**: Replaced hardcoded language mappings in `mappingXmlToInputFields.js` with dynamic mappings fetched via the new API. [[1]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85R95-R118) [[2]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L1124-R1151) [[3]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L1148-R1174)
* **Dropdown Placeholder**: Updated `resourceInformation.html` to include a placeholder option for the language dropdown.

### Testing Enhancements
* **Unit Tests for Language Mapping**: Added tests for `createLanguageMapping` in `mappingXmlToInputFields.test.js` to verify API data handling and fallback behavior.
* **Dropdown Initialization Tests**: Added tests for `setupLanguageDropdown` in `select.test.js` to ensure proper population of options and error handling.

## Notes for Reviewer
- If dropdown _language of dataset_ is working for you, the new endpoint `/vocabs/languages` ill work too.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
