### PR TITLE
Ensure comments are English

### DIFF
--- a/sample_settings_gem.php
+++ b/sample_settings_gem.php
@@ -31,11 +31,11 @@ $apiKeyGoogleMaps = 'xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxx';
 $apiKeyTimezone = 'your_timezone_api_key';
 
 // SETTINGS FOR GENERIC DATACITE RESEARCH DATA
-// maximale Anzahl der eingebbaren Titel
+// Maximum number of titles that can be entered
 $maxTitles = 2;
 // Show Contributor Persons form group
 $showContributorPersons = true;
-// Show Contrubutor Institutios form group
+// Show Contributor Institutions form group
 $showContributorInstitutions = true;
 // Show GCMD Thesauri form group
 $showGcmdThesauri = true;

--- a/sample_settings_msl.php
+++ b/sample_settings_msl.php
@@ -31,11 +31,11 @@ $apiKeyGoogleMaps = 'xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxx';
 $apiKeyTimezone = 'your_timezone_api_key';
 
 // SETTINGS FOR GENERIC DATACITE RESEARCH DATA
-// maximale Anzahl der eingebbaren Titel
+// Maximum number of titles that can be entered
 $maxTitles = 2;
 // Show Contributor Persons form group
 $showContributorPersons = true;
-// Show Contrubutor Institutios form group
+// Show Contributor Institutions form group
 $showContributorInstitutions = true;
 // Show GCMD Thesauri form group
 $showGcmdThesauri = true;

--- a/send_feedback_mail.php
+++ b/send_feedback_mail.php
@@ -13,11 +13,11 @@ function testGfzSmtpConnectivity() {
     
     error_log("=== GFZ SMTP Connectivity Test ===");
     
-    // DNS-Test
+    // DNS test
     $ip = gethostbyname($smtpHost);
     error_log("DNS Resolution: {$smtpHost} -> {$ip}");
     
-    // Port-Test
+    // Port test
     $connection = @fsockopen($smtpHost, $smtpPort, $errno, $errstr, 10);
     if ($connection) {
         error_log("Port {$smtpPort} on {$smtpHost} is OPEN");
@@ -40,7 +40,7 @@ function sendFeedbackMail(
 ) {
     global $smtpHost, $smtpPort, $smtpUser, $smtpPassword, $smtpSender, $feedbackAddress, $smtpSecure, $smtpAuth;
     
-    // Netzwerk-Test vor dem Versenden
+    // Network test before sending
     if (!testGfzSmtpConnectivity()) {
         echo json_encode(['success' => false, 'message' => 'GFZ SMTP Server nicht erreichbar. Siehe Logs für Details.']);
         return;
@@ -49,25 +49,25 @@ function sendFeedbackMail(
     $mail = new PHPMailer(true);
     
     try {
-        // Debug settings (für Troubleshooting)
+        // Debug settings (for troubleshooting)
         $mail->SMTPDebug = 2;
         $mail->Debugoutput = 'error_log';
         
-        // Server settings für GFZ SMTP
+        // Server settings for GFZ SMTP
         $mail->isSMTP();
         $mail->Host = $smtpHost;
         $mail->Port = $smtpPort;
         $mail->Timeout = 30;
         $mail->SMTPKeepAlive = false;
         
-        // Authentication für GFZ
+        // Authentication for GFZ
         $mail->SMTPAuth = filter_var($smtpAuth, FILTER_VALIDATE_BOOLEAN);
         if ($mail->SMTPAuth) {
             $mail->Username = $smtpUser;
             $mail->Password = $smtpPassword;
         }
         
-        // STARTTLS für GFZ
+        // STARTTLS for GFZ
         if (strtolower($smtpSecure) === 'tls') {
             $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
             $mail->SMTPAutoTLS = true;
@@ -85,7 +85,7 @@ function sendFeedbackMail(
         $mail->isHTML(false);
         $mail->Subject = 'Neues ELMO Feedback - ' . date('d.m.Y H:i:s');
         
-        // Email body auf Deutsch
+        // Email body in German
         $mail->Body = "Neues Feedback über ELMO erhalten:\n\n"
             . "1. Welche Funktionen des neuen Metadaten-Editors finden Sie besonders hilfreich?\n"
             . $feedbackQuestion1 . "\n\n"
@@ -124,7 +124,7 @@ function sendFeedbackMail(
         error_log("- PHPMailer Error: " . $mail->ErrorInfo);
         error_log("- Exception: " . $e->getMessage());
         
-        // Fallback: Feedback in Datei speichern
+        // Fallback: save feedback to file
         $logFile = '/var/www/html/feedback_backup.txt';
         $logEntry = "[" . date('Y-m-d H:i:s') . "] BACKUP FEEDBACK\n";
         $logEntry .= "An: " . $feedbackAddress . "\n";
@@ -141,7 +141,7 @@ function sendFeedbackMail(
     }
 }
 
-// POST-Request verarbeiten
+// Process POST request
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $feedbackQuestion1 = $_POST['feedbackQuestion1'] ?? '';
     $feedbackQuestion2 = $_POST['feedbackQuestion2'] ?? '';

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -47,11 +47,11 @@ function testGfzSmtpConnectivity() {
     
     error_log("=== GFZ SMTP Connectivity Test (XML Submit) ===");
     
-    // DNS-Test
+    // DNS test
     $ip = gethostbyname($smtpHost);
     error_log("DNS Resolution: {$smtpHost} -> {$ip}");
     
-    // Port-Test
+    // Port test
     $connection = @fsockopen($smtpHost, $smtpPort, $errno, $errstr, 10);
     if ($connection) {
         error_log("Port {$smtpPort} on {$smtpHost} is OPEN");
@@ -159,21 +159,21 @@ try {
     $mail->SMTPDebug = 2; // Enable verbose debug output
     $mail->Debugoutput = 'error_log';
 
-    // Server settings für GFZ SMTP
+    // Server settings for GFZ SMTP
     $mail->isSMTP();
-    $mail->Host = $smtpHost; // Direkter Hostname für GFZ
+    $mail->Host = $smtpHost; // Direct hostname for GFZ
     $mail->Port = $smtpPort;
     $mail->Timeout = 30;
     $mail->SMTPKeepAlive = false;
 
-    // Authentication für GFZ
+    // Authentication for GFZ
     $mail->SMTPAuth = filter_var($smtpAuth, FILTER_VALIDATE_BOOLEAN);
     if ($mail->SMTPAuth) {
         $mail->Username = $smtpUser;
         $mail->Password = $smtpPassword;
     }
 
-    // STARTTLS für GFZ
+    // STARTTLS for GFZ
     if (strtolower($smtpSecure) === 'tls') {
         $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
         $mail->SMTPAutoTLS = true;


### PR DESCRIPTION
This pull request focuses on improving code readability and consistency by translating German comments into English across several PHP files. The changes help make the codebase more accessible to non-German speakers and clarify the intent of various configuration and logic sections.

Comment translation and clarity improvements:

* Changed comments in `send_feedback_mail.php` to English, clarifying steps such as DNS and port tests, network testing, debug settings, server configuration, authentication, STARTTLS, email body, fallback handling, and POST request processing. [[1]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L16-R20) [[2]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L43-R43) [[3]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L52-R70) [[4]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L88-R88) [[5]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L127-R127) [[6]](diffhunk://#diff-0d65470af8405c666ff560010d9eb8b7a55e8b32ab32ff097f41ae57b2c3a844L144-R144)
* Updated comments in `send_xml_file.php` to English for SMTP connectivity tests and mail server configuration, authentication, and encryption settings. [[1]](diffhunk://#diff-4d214ad3a997b71611565fce576e5939dc7a9d7a518cd4c1136b775342795f91L50-R54) [[2]](diffhunk://#diff-4d214ad3a997b71611565fce576e5939dc7a9d7a518cd4c1136b775342795f91L162-R176)
* Translated configuration comments in `sample_settings_gem.php` and `sample_settings_msl.php` from German to English, improving clarity for settings related to title limits and contributor form groups. [[1]](diffhunk://#diff-4b354894c2a542fb447b483f00143b6c99fc6139939391c4526e281e117f6500L34-R38) [[2]](diffhunk://#diff-30b2df317fb4807431a95aa8b99871b1a4938c5fe8f840b36d8b4c4558856112L34-R38)