### PR TITLE
Doc: Enhanced and translate PHPDoc comments in tests

### DIFF
--- a/tests/SaveDescriptionsTest.php
+++ b/tests/SaveDescriptionsTest.php
@@ -6,12 +6,17 @@ use mysqli_sql_exception;
 require_once __DIR__ . '/../save/formgroups/save_descriptions.php';
 require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
 
+/**
+ * Test suite for saving description text sections.
+ */
 class SaveDescriptionsTest extends DatabaseTestCase
 {
     /**
-     * Alle vier Descriptions wurden ausgefüllt
+     * Saves all four description types and verifies persistence.
+     *
+     * @return void
      */
-    public function testSaveAllDescriptions()
+    public function testSaveAllDescriptions(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.ALL.DESCRIPTIONS",
@@ -60,9 +65,11 @@ class SaveDescriptionsTest extends DatabaseTestCase
     }
 
     /**
-     * Nur Abstract wurde ausgefüllt
+     * Saves only the abstract description and ensures others are ignored.
+     *
+     * @return void
      */
-    public function testSaveOnlyAbstract()
+    public function testSaveOnlyAbstract(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.ONLY.ABSTRACT",
@@ -99,9 +106,11 @@ class SaveDescriptionsTest extends DatabaseTestCase
     }
 
     /**
-     * Nur Methods wurde ausgefüllt (sollte fehlschlagen)
+     * Attempts to save only the methods description and expects failure.
+     *
+     * @return void
      */
-    public function testSaveOnlyMethods()
+    public function testSaveOnlyMethods(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.ONLY.METHODS",

--- a/tests/SaveDescriptionsTest.php
+++ b/tests/SaveDescriptionsTest.php
@@ -39,15 +39,15 @@ class SaveDescriptionsTest extends DatabaseTestCase
 
         $result = saveDescriptions($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "saveDescriptions sollte true zurückgeben, wenn alle Beschreibungen erfolgreich gespeichert wurden.");
+        $this->assertTrue($result, 'saveDescriptions should return true when all descriptions are saved successfully.');
 
-        // Überprüfen, ob alle vier Descriptions gespeichert wurden
+        // Verify that all four descriptions were saved
         $stmt = $this->connection->prepare("SELECT * FROM Description WHERE resource_id = ? ORDER BY type");
         $stmt->bind_param("i", $resource_id);
         $stmt->execute();
         $result = $stmt->get_result();
 
-        $this->assertEquals(4, $result->num_rows, "Es sollten genau vier Descriptions gespeichert worden sein.");
+        $this->assertEquals(4, $result->num_rows, 'Exactly four descriptions should be saved.');
 
         $expectedDescriptions = [
             ['type' => 'Abstract', 'description' => $postData['descriptionAbstract']],
@@ -58,8 +58,16 @@ class SaveDescriptionsTest extends DatabaseTestCase
 
         $index = 0;
         while ($description = $result->fetch_assoc()) {
-            $this->assertEquals($expectedDescriptions[$index]['type'], $description['type'], "Der Beschreibungstyp stimmt nicht überein.");
-            $this->assertEquals($expectedDescriptions[$index]['description'], $description['description'], "Der Inhalt der {$description['type']} Beschreibung stimmt nicht überein.");
+            $this->assertEquals(
+                $expectedDescriptions[$index]['type'],
+                $description['type'],
+                'The description type does not match.'
+            );
+            $this->assertEquals(
+                $expectedDescriptions[$index]['description'],
+                $description['description'],
+                "The content of the {$description['type']} description does not match."
+            );
             $index++;
         }
     }
@@ -92,17 +100,17 @@ class SaveDescriptionsTest extends DatabaseTestCase
 
         saveDescriptions($this->connection, $postData, $resource_id);
 
-        // Überprüfen, ob nur Abstract gespeichert wurde
+        // Verify that only the abstract was saved
         $stmt = $this->connection->prepare("SELECT * FROM Description WHERE resource_id = ?");
         $stmt->bind_param("i", $resource_id);
         $stmt->execute();
         $result = $stmt->get_result();
 
-        $this->assertEquals(1, $result->num_rows, "Es sollte genau eine Description gespeichert worden sein.");
+        $this->assertEquals(1, $result->num_rows, 'Exactly one description should be saved.');
 
         $description = $result->fetch_assoc();
-        $this->assertEquals('Abstract', $description['type'], "Der gespeicherte Beschreibungstyp sollte 'Abstract' sein.");
-        $this->assertEquals($postData['descriptionAbstract'], $description['description'], "Der Inhalt der Abstract Beschreibung stimmt nicht überein.");
+        $this->assertEquals('Abstract', $description['type'], "The saved description type should be 'Abstract'.");
+        $this->assertEquals($postData['descriptionAbstract'], $description['description'], 'The content of the abstract does not match.');
     }
 
     /**
@@ -133,14 +141,14 @@ class SaveDescriptionsTest extends DatabaseTestCase
 
         $result = saveDescriptions($this->connection, $postData, $resource_id);
 
-        $this->assertFalse($result, "Die Funktion sollte false zurückgeben, wenn nur Methods ausgefüllt ist.");
+        $this->assertFalse($result, 'The function should return false when only Methods is provided.');
 
-        // Überprüfen, ob keine Descriptions gespeichert wurden
+        // Verify that no descriptions were saved
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Description WHERE resource_id = ?");
         $stmt->bind_param("i", $resource_id);
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(0, $count, "Es sollten keine Descriptions gespeichert worden sein.");
+        $this->assertEquals(0, $count, 'No descriptions should be saved.');
     }
 }

--- a/tests/SaveFreekeywordsTest.php
+++ b/tests/SaveFreekeywordsTest.php
@@ -5,12 +5,17 @@ use mysqli_sql_exception;
 
 require_once __DIR__ . '/../save/formgroups/save_freekeywords.php';
 
+/**
+ * Test suite for saving free keywords.
+ */
 class SaveFreekeywordsTest extends DatabaseTestCase
 {
     /**
-     * Ein einzelnes, noch nicht kuratiertes, Freies Keyword wurde eingegeben
+     * Saves a new uncurated free keyword and verifies its storage.
+     *
+     * @return void
      */
-    public function testSaveSingleUncuratedFreeKeyword()
+    public function testSaveSingleUncuratedFreeKeyword(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.SINGLE.UNCURATED",
@@ -37,8 +42,8 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $result = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($result, "Das freie Keyword sollte gespeichert worden sein.");
-        $this->assertEquals(0, $result['isCurated'], "Das Keyword sollte als nicht kuratiert markiert sein.");
+        $this->assertNotNull($result, 'The free keyword should be saved.');
+        $this->assertEquals(0, $result['isCurated'], 'The keyword should be marked as uncurated.');
 
         // Check if the relation to the resource was created
         $stmt = $this->connection->prepare("SELECT * FROM Resource_has_Free_Keywords WHERE Resource_resource_id = ? AND Free_Keywords_free_keywords_id = ?");
@@ -46,13 +51,15 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $relationResult = $stmt->get_result();
 
-        $this->assertEquals(1, $relationResult->num_rows, "Es sollte eine Verknüpfung zwischen Resource und Free Keyword existieren.");
+        $this->assertEquals(1, $relationResult->num_rows, 'A relation between Resource and Free Keyword should exist.');
     }
 
     /**
-     * Ein freies Keyword wurde eingegeben, das bereits existiert, aber noch nicht kuratiert wurde
+     * Saves a free keyword that already exists but remains uncurated.
+     *
+     * @return void
      */
-    public function testSaveExistingUncuratedFreeKeyword()
+    public function testSaveExistingUncuratedFreeKeyword(): void
     {
         // First, insert an uncurated keyword
         $this->connection->query("INSERT INTO Free_Keywords (free_keyword, isCurated) VALUES ('ExistingUncurated', 0)");
@@ -83,7 +90,7 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(1, $count, "Es sollte kein neues Keyword erstellt worden sein.");
+        $this->assertEquals(1, $count, 'No new keyword should have been created.');
 
         // Check if the relation to the resource was created
         $stmt = $this->connection->prepare("SELECT * FROM Resource_has_Free_Keywords WHERE Resource_resource_id = ? AND Free_Keywords_free_keywords_id = ?");
@@ -91,13 +98,15 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $relationResult = $stmt->get_result();
 
-        $this->assertEquals(1, $relationResult->num_rows, "Es sollte eine Verknüpfung zwischen Resource und dem existierenden Free Keyword erstellt worden sein.");
+        $this->assertEquals(1, $relationResult->num_rows, 'A link between the resource and the existing free keyword should be created.');
     }
 
     /**
-     * Ein Keyword wurde eingegeben, das bereits existiert und kuratiert wurde
+     * Saves a free keyword that already exists and is curated.
+     *
+     * @return void
      */
-    public function testSaveExistingCuratedFreeKeyword()
+    public function testSaveExistingCuratedFreeKeyword(): void
     {
         // First, insert a curated keyword
         $this->connection->query("INSERT INTO Free_Keywords (free_keyword, isCurated) VALUES ('ExistingCurated', 1)");
@@ -128,7 +137,7 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(1, $count, "Es sollte kein neues Keyword erstellt worden sein.");
+        $this->assertEquals(1, $count, 'No new keyword should have been created.');
 
         // Check if the relation to the resource was created
         $stmt = $this->connection->prepare("SELECT * FROM Resource_has_Free_Keywords WHERE Resource_resource_id = ? AND Free_Keywords_free_keywords_id = ?");
@@ -136,13 +145,15 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $relationResult = $stmt->get_result();
 
-        $this->assertEquals(1, $relationResult->num_rows, "Es sollte eine Verknüpfung zwischen Resource und dem existierenden kuratierten Free Keyword erstellt worden sein.");
+        $this->assertEquals(1, $relationResult->num_rows, 'A link between the resource and the existing curated free keyword should be created.');
     }
 
     /**
-     * Mehrere Keywords wurden ausgewählt, manche existieren bereits, manche sind kuratiert und manche nicht
+     * Saves multiple keywords including curated and uncurated ones.
+     *
+     * @return void
      */
-    public function testSaveMultipleMixedFreeKeywords()
+    public function testSaveMultipleMixedFreeKeywords(): void
     {
         // Insert some existing keywords
         $this->connection->query("INSERT INTO Free_Keywords (free_keyword, isCurated) VALUES ('ExistingCurated1', 1), ('ExistingUncurated1', 0)");
@@ -177,7 +188,7 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(4, $count, "Es sollten insgesamt 4 Keywords in der Datenbank sein.");
+        $this->assertEquals(4, $count, 'There should be four keywords in the database.');
 
         // Check if all keywords are linked to the resource
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource_has_Free_Keywords WHERE Resource_resource_id = ?");
@@ -185,7 +196,7 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(4, $count, "Es sollten 4 Verknüpfungen zwischen der Resource und den Free Keywords existieren.");
+        $this->assertEquals(4, $count, 'There should be four relations between the resource and the free keywords.');
 
         // Check the curation status of the keywords
         $stmt = $this->connection->prepare("SELECT free_keyword, isCurated FROM Free_Keywords");
@@ -201,14 +212,20 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         ];
 
         foreach ($keywords as $keyword) {
-            $this->assertEquals($expectedStatus[$keyword['free_keyword']], $keyword['isCurated'], "Der Kuratierungsstatus für '{$keyword['free_keyword']}' ist nicht korrekt.");
+            $this->assertEquals(
+                $expectedStatus[$keyword['free_keyword']],
+                $keyword['isCurated'],
+                "The curation status for '{$keyword['free_keyword']}' is incorrect."
+            );
         }
     }
 
     /**
-     * Das Eingabefeld für Free Keywords wurde nicht befüllt
+     * Verifies that saving without providing free keywords does not create entries.
+     *
+     * @return void
      */
-    public function testSaveNoFreeKeywords()
+    public function testSaveNoFreeKeywords(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.NO.FREE.KEYWORDS",
@@ -233,7 +250,7 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(0, $count, "Es sollten keine Free Keywords gespeichert worden sein.");
+        $this->assertEquals(0, $count, 'No free keywords should be saved.');
 
         // Check if no relations were created
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource_has_Free_Keywords WHERE Resource_resource_id = ?");
@@ -241,6 +258,6 @@ class SaveFreekeywordsTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(0, $count, "Es sollten keine Verknüpfungen zwischen Resource und Free Keywords existieren.");
+        $this->assertEquals(0, $count, 'No relations between the resource and free keywords should exist.');
     }
 }

--- a/tests/SaveGGMsProperties.php
+++ b/tests/SaveGGMsProperties.php
@@ -6,12 +6,17 @@ use mysqli_sql_exception;
 
 require_once __DIR__ . '/../save/formgroups/save_ggmsproperties.php';
 
+/**
+ * Test suite for saving Gravity Gradient Model properties.
+ */
 class SaveGGMsProperties extends DatabaseTestCase
 {
-     /**
-     * Test saving a GGM Properties entry with all fields populated.
+    /**
+     * Tests saving a GGM Properties entry with all fields populated.
+     *
+     * @return void
      */
-    public function testSaveFullGGMsProperties()
+    public function testSaveFullGGMsProperties(): void
     {
         $resource_id = $this->createResource('GGM.FULL', 'Test GGM Full');
 
@@ -39,9 +44,11 @@ class SaveGGMsProperties extends DatabaseTestCase
     }
 
     /**
-     * Test saving GGM Properties with only required fields.
+     * Tests saving GGM Properties with only required fields.
+     *
+     * @return void
      */
-    public function testSaveRequiredGGMsProperties()
+    public function testSaveRequiredGGMsProperties(): void
     {
         $resource_id = $this->createResource('GGM.REQUIRED', 'Test GGM Required');
 
@@ -63,9 +70,11 @@ class SaveGGMsProperties extends DatabaseTestCase
     }
 
     /**
-     * Test saving GGM Properties with missing required fields (should not save).
+     * Tests saving GGM Properties with missing required fields.
+     *
+     * @return void
      */
-    public function testSaveGGMsPropertiesMissingRequired()
+    public function testSaveGGMsPropertiesMissingRequired(): void
     {
         $resource_id = $this->createResource('GGM.MISSING', 'Test GGM Missing');
 

--- a/tests/SaveSpatialTemporalCoverageTest.php
+++ b/tests/SaveSpatialTemporalCoverageTest.php
@@ -60,19 +60,19 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
         $stmt->bind_param("s", $postData["tscDescription"][0]);
         $stmt->execute();
-        $stc = $stmt->get_result()->fetch_assoc();
+        $retrievedStc = $stmt->get_result()->fetch_assoc();
 
         // Assert all fields were saved correctly
-        $this->assertNotNull($stc, 'STC entry should be saved in the database');
-        $this->assertEquals($postData["tscLatitudeMin"][0], $stc["latitudeMin"]);
-        $this->assertEquals($postData["tscLatitudeMax"][0], $stc["latitudeMax"]);
-        $this->assertEquals($postData["tscLongitudeMin"][0], $stc["longitudeMin"]);
-        $this->assertEquals($postData["tscLongitudeMax"][0], $stc["longitudeMax"]);
-        $this->assertEquals($postData["tscDateStart"][0], $stc["dateStart"]);
-        $this->assertEquals($postData["tscTimeStart"][0], $stc["timeStart"]);
-        $this->assertEquals($postData["tscDateEnd"][0], $stc["dateEnd"]);
-        $this->assertEquals($postData["tscTimeEnd"][0], $stc["timeEnd"]);
-        $this->assertEquals($postData["tscTimezone"][0], $stc["timezone"]);
+        $this->assertNotNull($retrievedStc, 'STC entry should be saved in the database');
+        $this->assertEquals($postData["tscLatitudeMin"][0], $retrievedStc["latitudeMin"]);
+        $this->assertEquals($postData["tscLatitudeMax"][0], $retrievedStc["latitudeMax"]);
+        $this->assertEquals($postData["tscLongitudeMin"][0], $retrievedStc["longitudeMin"]);
+        $this->assertEquals($postData["tscLongitudeMax"][0], $retrievedStc["longitudeMax"]);
+        $this->assertEquals($postData["tscDateStart"][0], $retrievedStc["dateStart"]);
+        $this->assertEquals($postData["tscTimeStart"][0], $retrievedStc["timeStart"]);
+        $this->assertEquals($postData["tscDateEnd"][0], $retrievedStc["dateEnd"]);
+        $this->assertEquals($postData["tscTimeEnd"][0], $retrievedStc["timeEnd"]);
+        $this->assertEquals($postData["tscTimezone"][0], $retrievedStc["timezone"]);
 
         // Verify resource linkage
         $stmt = $this->connection->prepare(
@@ -80,7 +80,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
              WHERE Resource_resource_id = ? 
              AND Spatial_Temporal_Coverage_spatial_temporal_coverage_id = ?"
         );
-        $stmt->bind_param("ii", $resource_id, $stc["spatial_temporal_coverage_id"]);
+        $stmt->bind_param("ii", $resource_id, $retrievedStc["spatial_temporal_coverage_id"]);
         $stmt->execute();
         $relation = $stmt->get_result()->fetch_assoc();
 
@@ -183,13 +183,13 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
         $stmt->bind_param("s", $postData["tscDescription"][0]);
         $stmt->execute();
-        $stc = $stmt->get_result()->fetch_assoc();
+        $retrievedStc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, 'STC entry should be saved');
-        $this->assertEquals($postData["tscLatitudeMin"][0], $stc["latitudeMin"]);
-        $this->assertNull($stc["latitudeMax"]);
-        $this->assertEquals($postData["tscLongitudeMin"][0], $stc["longitudeMin"]);
-        $this->assertNull($stc["longitudeMax"]);
+        $this->assertNotNull($retrievedStc, 'STC entry should be saved');
+        $this->assertEquals($postData["tscLatitudeMin"][0], $retrievedStc["latitudeMin"]);
+        $this->assertNull($retrievedStc["latitudeMax"]);
+        $this->assertEquals($postData["tscLongitudeMin"][0], $retrievedStc["longitudeMin"]);
+        $this->assertNull($retrievedStc["longitudeMax"]);
     }
 
     /**
@@ -326,13 +326,13 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
         $stmt->bind_param("s", $postData["tscDescription"][0]);
         $stmt->execute();
-        $stc = $stmt->get_result()->fetch_assoc();
+        $retrievedStc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, 'The STC entry should be saved.');
-        $this->assertEquals($postData["tscDateStart"][0], $stc["dateStart"]);
-        $this->assertEquals($postData["tscDateEnd"][0], $stc["dateEnd"]);
-        $this->assertNull($stc["timeStart"]);
-        $this->assertNull($stc["timeEnd"]);
+        $this->assertNotNull($retrievedStc, 'The STC entry should be saved.');
+        $this->assertEquals($postData["tscDateStart"][0], $retrievedStc["dateStart"]);
+        $this->assertEquals($postData["tscDateEnd"][0], $retrievedStc["dateEnd"]);
+        $this->assertNull($retrievedStc["timeStart"]);
+        $this->assertNull($retrievedStc["timeEnd"]);
     }
 
     /**
@@ -378,12 +378,12 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
         $stmt->bind_param("s", $postData["tscDescription"][0]);
         $stmt->execute();
-        $stc = $stmt->get_result()->fetch_assoc();
+        $retrievedStc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, 'The STC entry should be saved.');
-        $this->assertEquals($postData["tscDateStart"][0], $stc["dateStart"]);
-        $this->assertEquals($postData["tscDateEnd"][0], $stc["dateEnd"]);
-        $this->assertNull($stc["timeStart"]);
-        $this->assertEquals($postData["tscTimeEnd"][0], $stc["timeEnd"]);
+        $this->assertNotNull($retrievedStc, 'The STC entry should be saved.');
+        $this->assertEquals($postData["tscDateStart"][0], $retrievedStc["dateStart"]);
+        $this->assertEquals($postData["tscDateEnd"][0], $retrievedStc["dateEnd"]);
+        $this->assertNull($retrievedStc["timeStart"]);
+        $this->assertEquals($postData["tscTimeEnd"][0], $retrievedStc["timeEnd"]);
     }
 }

--- a/tests/SaveSpatialTemporalCoverageTest.php
+++ b/tests/SaveSpatialTemporalCoverageTest.php
@@ -54,7 +54,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "Function should return true when all fields are properly saved.");
+        $this->assertTrue($result, 'Function should return true when all fields are properly saved.');
 
         // Verify saved data
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
@@ -63,7 +63,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stc = $stmt->get_result()->fetch_assoc();
 
         // Assert all fields were saved correctly
-        $this->assertNotNull($stc, "STC entry should be saved in the database");
+        $this->assertNotNull($stc, 'STC entry should be saved in the database');
         $this->assertEquals($postData["tscLatitudeMin"][0], $stc["latitudeMin"]);
         $this->assertEquals($postData["tscLatitudeMax"][0], $stc["latitudeMax"]);
         $this->assertEquals($postData["tscLongitudeMin"][0], $stc["longitudeMin"]);
@@ -84,13 +84,15 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt->execute();
         $relation = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($relation, "Resource-STC relationship should exist");
+        $this->assertNotNull($relation, 'Resource-STC relationship should exist');
     }
 
     /**
-     * Eingabe von 3 vollständig ausgefüllten Datensätzen
+     * Saves three fully populated records and validates their persistence.
+     *
+     * @return void
      */
-    public function testSaveThreeCompleteSets()
+    public function testSaveThreeCompleteSets(): void
     {
         $resourceData = [
             "doi" => "10.5880/GFZ.TEST.THREE.SETS",
@@ -119,14 +121,14 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "Die Funktion sollte true zurückgeben.");
+        $this->assertTrue($result, 'The function should return true.');
 
         // Check if all three STCs were saved correctly
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Spatial_Temporal_Coverage");
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(3, $count, "Es sollten genau drei STC-Einträge gespeichert worden sein.");
+        $this->assertEquals(3, $count, 'Exactly three STC entries should be saved.');
 
         // Check if all three relations to the resource were created
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource_has_Spatial_Temporal_Coverage WHERE Resource_resource_id = ?");
@@ -134,7 +136,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(3, $count, "Es sollten genau drei Verknüpfungen zwischen Resource und STC existieren.");
+        $this->assertEquals(3, $count, 'Exactly three relations between the resource and STC should exist.');
     }
 
     /**
@@ -175,7 +177,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "Function should return true when saving with null max coordinates");
+        $this->assertTrue($result, 'Function should return true when saving with null max coordinates');
 
         // Verify saved data
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
@@ -183,7 +185,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt->execute();
         $stc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, "STC entry should be saved");
+        $this->assertNotNull($stc, 'STC entry should be saved');
         $this->assertEquals($postData["tscLatitudeMin"][0], $stc["latitudeMin"]);
         $this->assertNull($stc["latitudeMax"]);
         $this->assertEquals($postData["tscLongitudeMin"][0], $stc["longitudeMin"]);
@@ -226,13 +228,13 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertFalse($result, "Function should return false with invalid coordinates");
+        $this->assertFalse($result, 'Function should return false with invalid coordinates');
 
         // Verify no records were saved
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Spatial_Temporal_Coverage");
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
-        $this->assertEquals(0, $count, "No STC entries should be saved with invalid coordinates");
+        $this->assertEquals(0, $count, 'No STC entries should be saved with invalid coordinates');
     }
 
     /**
@@ -271,14 +273,14 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertFalse($result, "Die Funktion sollte false zurückgeben wenn das Startdatum fehlt.");
+        $this->assertFalse($result, 'The function should return false when the start date is missing.');
 
         // Check that no STC was saved
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Spatial_Temporal_Coverage");
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(0, $count, "Es sollten keine STC-Einträge gespeichert worden sein.");
+        $this->assertEquals(0, $count, 'No STC entries should be saved.');
     }
 
     /**
@@ -318,7 +320,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "Die Funktion sollte true zurückgeben wenn nur die Uhrzeiten fehlen.");
+        $this->assertTrue($result, 'The function should return true when only the times are missing.');
 
         // Check if the STC was saved correctly
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
@@ -326,7 +328,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt->execute();
         $stc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, "Der STC-Eintrag sollte gespeichert worden sein.");
+        $this->assertNotNull($stc, 'The STC entry should be saved.');
         $this->assertEquals($postData["tscDateStart"][0], $stc["dateStart"]);
         $this->assertEquals($postData["tscDateEnd"][0], $stc["dateEnd"]);
         $this->assertNull($stc["timeStart"]);
@@ -370,7 +372,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
 
         $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
 
-        $this->assertTrue($result, "Die Funktion sollte true zurückgeben wenn nur eine Uhrzeit fehlt.");
+        $this->assertTrue($result, 'The function should return true when only one time is missing.');
 
         // Check if the STC was saved correctly
         $stmt = $this->connection->prepare("SELECT * FROM Spatial_Temporal_Coverage WHERE Description = ?");
@@ -378,7 +380,7 @@ class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $stmt->execute();
         $stc = $stmt->get_result()->fetch_assoc();
 
-        $this->assertNotNull($stc, "Der STC-Eintrag sollte gespeichert worden sein.");
+        $this->assertNotNull($stc, 'The STC entry should be saved.');
         $this->assertEquals($postData["tscDateStart"][0], $stc["dateStart"]);
         $this->assertEquals($postData["tscDateEnd"][0], $stc["dateEnd"]);
         $this->assertNull($stc["timeStart"]);

--- a/tests/js/affiliations.test.js
+++ b/tests/js/affiliations.test.js
@@ -3,6 +3,9 @@ const path = require('path');
 
 let $;
 
+/**
+ * Mock implementation of Tagify used for testing.
+ */
 class MockTagify {
   constructor(el, options) {
     this.el = el;
@@ -42,6 +45,9 @@ class MockTagify {
   }
 }
 
+/**
+ * Tests for the affiliations.js module.
+ */
 describe('affiliations.js', () => {
   beforeEach(() => {
     document.body.innerHTML = `
@@ -69,6 +75,9 @@ describe('affiliations.js', () => {
     window.eval(script);
   });
 
+  /**
+   * Ensures a Tagify instance is created with the provided whitelist.
+   */
   test('autocompleteAffiliations creates Tagify instance with whitelist', () => {
     const data = [ { id: '1', name: 'TestOrg' } ];
     window.autocompleteAffiliations('input-author-affiliation', 'input-author-rorid', data);
@@ -78,6 +87,9 @@ describe('affiliations.js', () => {
     expect(input.tagify.whitelist).toEqual(['TestOrg']);
   });
 
+  /**
+   * Verifies that adding tags updates the hidden field and hides the dropdown for unknown values.
+   */
   test('adding a tag updates hidden field and closes dropdown for non-whitelist', () => {
     const data = [ { id: '1', name: 'Allowed' } ];
     window.autocompleteAffiliations('input-author-affiliation', 'input-author-rorid', data);
@@ -91,6 +103,9 @@ describe('affiliations.js', () => {
     expect(input.tagify.dropdown.hide).toHaveBeenCalled();
   });
 
+  /**
+   * Checks that the remove event clears tags when no contact person is specified.
+   */
   test('remove event clears tags when contact person empty', () => {
     const data = [ { id: '1', name: 'Org' } ];
     window.autocompleteAffiliations('input-author-affiliation', 'input-author-rorid', data);
@@ -103,6 +118,9 @@ describe('affiliations.js', () => {
     expect(input.tagify.value.length).toBe(0);
   });
 
+  /**
+   * Confirms that input events resize the tagify input width.
+   */
   test('input event resizes input width', () => {
     const data = [];
     window.autocompleteAffiliations('input-author-affiliation', 'input-author-rorid', data);
@@ -112,6 +130,9 @@ describe('affiliations.js', () => {
     expect(input.tagify.DOM.input.style.width).toBe('40px');
   });
 
+  /**
+   * Ensures refreshTagifyInstances updates the whitelist while retaining existing tags.
+   */
   test('refreshTagifyInstances updates whitelist and keeps tags', () => {
     const data = [ { id: '1', name: 'First' } ];
     window.autocompleteAffiliations('input-author-affiliation', 'input-author-rorid', data);


### PR DESCRIPTION
This pull request refactors and improves the test suites for saving descriptions, free keywords, Gravity Gradient Model properties, and spatial/temporal coverage. The main focus is on enhancing code readability, consistency, and maintainability. Changes include updating test method signatures to specify `void` return types, converting comments and assertion messages from German to clear English, and providing more descriptive docblocks for each test case.

## Changes
### Test suite improvements and code consistency
* All test method signatures in `tests/SaveDescriptionsTest.php`, `tests/SaveFreekeywordsTest.php`, `tests/SaveGGMsProperties.php`, and `tests/SaveSpatialTemporalCoverageTest.php` now explicitly declare `: void` return types, improving type safety and clarity. [[1]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1R9-R19) [[2]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817R8-R18) [[3]](diffhunk://#diff-e448d80de72af575ebefaa23f3a400803b27b605342c272f35238c947fce27cfR9-R19) [[4]](diffhunk://#diff-43f36939c5973e611bcab70fa47f2207dc6f1d59754d4a2c21f24629b86a2270L57-R57)
* Assertion messages and code comments have been translated from German to English and made more descriptive, enhancing readability and maintainability across all affected test files. [[1]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1L37-R50) [[2]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1L56-R80) [[3]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1L88-R121) [[4]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1L127-R152) [[5]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L40-R62) [[6]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L86-R109) [[7]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L131-R156) [[8]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L180-R199) [[9]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L204-R228) [[10]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817L236-R261) [[11]](diffhunk://#diff-43f36939c5973e611bcab70fa47f2207dc6f1d59754d4a2c21f24629b86a2270L66-R66) [[12]](diffhunk://#diff-43f36939c5973e611bcab70fa47f2207dc6f1d59754d4a2c21f24629b86a2270L122-R139) [[13]](diffhunk://#diff-43f36939c5973e611bcab70fa47f2207dc6f1d59754d4a2c21f24629b86a2270L178-R188)
* Docblocks have been added and improved for each test method, providing clear descriptions of the test purpose and expected behavior. [[1]](diffhunk://#diff-c3f63078e98a4966428b03d61b54e48ffe450f661b2ed52b533a58a0f3ff25d1R9-R19) [[2]](diffhunk://#diff-0caa1ec74d57be1fb741f5023fb9408d1810a8228ad99efc02b70f7ce2521817R8-R18) [[3]](diffhunk://#diff-e448d80de72af575ebefaa23f3a400803b27b605342c272f35238c947fce27cfR9-R19) [[4]](diffhunk://#diff-43f36939c5973e611bcab70fa47f2207dc6f1d59754d4a2c21f24629b86a2270L57-R57)

## Notes for Reviewer
No changes to test logic or functionality were made; all modifications are focused on documentation, style, and code clarity.


## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
