### PR TITLE
Fix: Set scheme name for MSL keyword to EPOS MSL vocabulary

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -31,6 +31,7 @@
                             <li>Translation of messages in save and submit workflow</li>
                             <li>Automatic detection and differentiation of DOIs and URLs fixed</li>
                             <li>Thesaurus keywords: fix the search in the modals to work propperly and independently</li>
+                            <li>MSL keywords are saved with the "EPOS MSL vocabulary" scheme</li>
                         </ul>
                     </li>
                     <li><strong>Documentation:</strong>
@@ -45,7 +46,6 @@
                             <li>First unit tests for JavaScript Code with Jest</li>
                             <li>Replaced CDN links with npm packages</li>
                             <li>Increased development speed: Mounted docker volumes for the folders subjected to change</li>
-
                         </ul>
                     </li>
                 </ul>

--- a/save/formgroups/save_thesauruskeywords.php
+++ b/save/formgroups/save_thesauruskeywords.php
@@ -57,6 +57,12 @@ function processThesaurusKeyword($connection, $entry, $resource_id, $field)
     $value = $entry['value'];
     $valueURI = isset($entry['id']) ? $entry['id'] : null;       // Uses the URI if available
     $scheme = isset($entry['scheme']) ? $entry['scheme'] : $field; // If no scheme, use the field name
+
+    // Workaround until Utrecht fixed it in the original source, TODO: Remove this when fixed
+    if ($field === 'MSLKeywords') {
+        $scheme = 'EPOS MSL vocabulary';
+    }
+
     $schemeURI = isset($entry['schemeURI']) ? $entry['schemeURI'] : ''; // Optional: URI of the scheme
     $language = isset($entry['language']) ? $entry['language'] : 'en'; // Default language: English
 

--- a/save/formgroups/save_thesauruskeywords.php
+++ b/save/formgroups/save_thesauruskeywords.php
@@ -58,7 +58,7 @@ function processThesaurusKeyword($connection, $entry, $resource_id, $field)
     $valueURI = isset($entry['id']) ? $entry['id'] : null;       // Uses the URI if available
     $scheme = isset($entry['scheme']) ? $entry['scheme'] : $field; // If no scheme, use the field name
 
-    // Workaround until Utrecht fixed it in the original source, TODO: Remove this when fixed
+    // Workaround until Utrecht fixed it in the original source
     if ($field === 'MSLKeywords') {
         $scheme = 'EPOS MSL vocabulary';
     }


### PR DESCRIPTION
This pull request introduces a targeted fix to how MSL keywords are handled and documented. The main change ensures that MSL keywords are consistently saved with the "EPOS MSL vocabulary" scheme, both in the backend logic and in the changelog documentation.

- Fixes #588 

## Changes
### Thesaurus keyword handling
* Updated the `processThesaurusKeyword` function in `save/formgroups/save_thesauruskeywords.php` to always save MSL keywords with the "EPOS MSL vocabulary" scheme as a workaround for a known upstream issue.

### Documentation
* Added a changelog entry in `doc/changelog.html` noting that MSL keywords are now saved with the "EPOS MSL vocabulary" scheme.
* Minor formatting adjustment in the changelog by removing an unnecessary blank line.

## Notes for Reviewer
None.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
