### PR TITLE
Fix: All ELMOs send XMLs to only one mail adress

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ To install them: npm install
   - `$smtpPassword`: Password of the mailbox
   - `$smtpSender`: Name of the sender in the feedback mails
   - `$feedbackAddress`: Email Address to which the feedback is sent
-  - `$xmlSubmitAddress`: Email Address to which the finished XML file is sent
+  - `$xmlSubmitAddress`: Email Address to which the finished XML file is sent. When deploying the three frontend variants via `docker-compose.prod.yml`, configure this via the environment variables `XML_SUBMIT_ADDRESS`, `XML_SUBMIT_ADDRESS_MSL`, and `XML_SUBMIT_ADDRESS_GEM` for the standard, MSL, and GEM variants respectively.
   - `$showContributorPersons`: Specifies whether the form group Contributor Persons should be displayed (true/false).
   - `$showContributorInstitutions`: Specifies whether the form group Contributor Institutions should be displayed (true/false).
   - `$showMslLabs`: Specifies whether the form group Originating Laboratory should be displayed (true/false).

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,7 +70,7 @@ services:
       SMTP_SECURE: ${SMTP_SECURE}
       SMTP_SENDER: ${SMTP_SENDER}
       FEEDBACK_ADDRESS: ${FEEDBACK_ADDRESS}
-      XML_SUBMIT_ADDRESS: ${XML_SUBMIT_ADDRESS}
+      XML_SUBMIT_ADDRESS: ${XML_SUBMIT_ADDRESS_MSL}
       TZ: Europe/Berlin
       # Flags for msl
       SHOW_MSL_LABS: "true"
@@ -109,7 +109,7 @@ services:
       SMTP_SECURE: ${SMTP_SECURE}
       SMTP_SENDER: ${SMTP_SENDER}
       FEEDBACK_ADDRESS: ${FEEDBACK_ADDRESS}
-      XML_SUBMIT_ADDRESS: ${XML_SUBMIT_ADDRESS}
+      XML_SUBMIT_ADDRESS: ${XML_SUBMIT_ADDRESS_GEM}
       TZ: Europe/Berlin
       # Flags for gem
       SHOW_MSL_LABS: "false"

--- a/sample_settings_gem.php
+++ b/sample_settings_gem.php
@@ -76,7 +76,7 @@ $smtpSender = 'your_smtp_sender_email';
 $feedbackAddress = 'feedback@example.com';
 
 // Target address for XML submit
-$xmlSubmitAddress = 'xmlsubmit@example.com';
+$xmlSubmitAddress = getenv('XML_SUBMIT_ADDRESS_GEM') ?: 'xmlsubmit@example.com';
 
 function getSettings($setting)
 {

--- a/sample_settings_msl.php
+++ b/sample_settings_msl.php
@@ -78,7 +78,7 @@ $smtpAuth   = getenv('SMTP_AUTH') ?: '';
 $feedbackAddress = getenv('FEEDBACK_ADDRESS') ?: 'feedback@example.com';
 
 // Target address for XML submit
-$xmlSubmitAddress = getenv('XML_SUBMIT_ADDRESS') ?: 'xmlsubmit@example.com';
+$xmlSubmitAddress = getenv('XML_SUBMIT_ADDRESS_MSL') ?: 'xmlsubmit@example.com';
 
 function getSettings($setting)
 {

--- a/settings.msl.php
+++ b/settings.msl.php
@@ -78,7 +78,7 @@ $smtpAuth   = getenv('SMTP_AUTH') ?: '';
 $feedbackAddress = getenv('FEEDBACK_ADDRESS') ?: 'feedback@example.com';
 
 // Target address for XML submit
-$xmlSubmitAddress = getenv('XML_SUBMIT_ADDRESS') ?: 'xmlsubmit@example.com';
+$xmlSubmitAddress = getenv('XML_SUBMIT_ADDRESS_MSL') ?: 'xmlsubmit@example.com';
 
 function getSettings($setting)
 {

--- a/stack.env
+++ b/stack.env
@@ -12,4 +12,6 @@ SMTP_SECURE=tls
 SMTP_SENDER=gfzelmo@gmail.com
 FEEDBACK_ADDRESS=holger.ehrmann@gfz.de
 XML_SUBMIT_ADDRESS=holger.ehrmann@gfz.de
+XML_SUBMIT_ADDRESS_MSL=holger.ehrmann@gfz.de
+XML_SUBMIT_ADDRESS_GEM=holger.ehrmann@gfz.de
 ALLOWED_SENDER_DOMAINS=gmail.com


### PR DESCRIPTION
This pull request updates the way XML submission addresses are configured for the MSL and GEM services, making the environment variables more explicit and reducing the risk of misconfiguration. The changes ensure that each service uses its own dedicated environment variable for the XML submission address, both in the Docker Compose configuration and in the PHP settings files.

Fixes #683 

## Changes
### Configuration improvements
* Added new environment variables `XML_SUBMIT_ADDRESS_MSL` and `XML_SUBMIT_ADDRESS_GEM` to `stack.env` for clearer separation of XML submission addresses for MSL and GEM services.
* Updated `docker-compose.prod.yml` to use `XML_SUBMIT_ADDRESS_MSL` for the MSL service and `XML_SUBMIT_ADDRESS_GEM` for the GEM service, replacing the previous shared `XML_SUBMIT_ADDRESS`. [[1]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L73-R73) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L112-R112)

### Codebase updates
* Modified `sample_settings_msl.php` and `settings.msl.php` to use the new `XML_SUBMIT_ADDRESS_MSL` environment variable for the MSL XML submission address. [[1]](diffhunk://#diff-30b2df317fb4807431a95aa8b99871b1a4938c5fe8f840b36d8b4c4558856112L81-R81) [[2]](diffhunk://#diff-0e3211f95ab49b48bdeec8513368c4a829b40d62bb5139ca68ec991766a3b3f9L81-R81)
* Updated `sample_settings_gem.php` to use the new `XML_SUBMIT_ADDRESS_GEM` environment variable for the GEM XML submission address.

## Notes for Reviewer
Please review the changes. Live testing have to be done on prod.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
