### PR TITLE
Fix: Save and submit not starting on Safari browser

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -20,6 +20,7 @@
                     </li>
                     <li><strong>Fixes:</strong>
                         <ul>
+                            <li>Save and submit not starting on Safari browser</li>
                         </ul>
                     </li>
                     <li><strong>Documentation:</strong>

--- a/js/validation.js
+++ b/js/validation.js
@@ -11,6 +11,15 @@ $(() => {
   const saveHandler = new SaveHandler('form-mde', 'modal-saveas', 'modal-notification');
   const submitHandler = new SubmitHandler('form-mde', 'modal-submit', 'modal-notification');
 
+  // Keep track of the clicked submit button. Safari does not retain the
+  // activeElement during form submission, which causes document.activeElement
+  // to point to the form instead of the button that triggered the submit event.
+  // Fix: Store the action on click and fall back to the submitter property when available.
+  let pendingAction = null;
+  $('#form-mde button[type="submit"]').on('click', function () {
+    pendingAction = $(this).data('action');
+  });
+
   // Form submit event handler
   $('#form-mde').on('submit', function (e) {
     // Prevent default form submission


### PR DESCRIPTION
This pull request addresses a bug where the "Save and submit" functionality was not working correctly on the Safari browser. The main change involves updating the form submission logic to reliably track which submit button was clicked, even in browsers like Safari that do not retain the active element during form submission.

## Changes
### Bug fix for Safari browser
* Added logic in `js/validation.js` to track the clicked submit button by storing its action on click, ensuring the correct action is used during form submission on Safari.

### Documentation update
* Updated the changelog in `doc/changelog.html` to note the fix for "Save and submit not starting on Safari browser."

## Notes for Reviewer
None.

## Checklist
- [ ] Mein Code folgt dem Style Guide.
- [ ] Ich habe selbst eine Code Review durchgeführt.
- [ ] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [ ] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [ ] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
None.
