### PR TITLE
fix: allow coverage badge push in jest workflow

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,7 +9,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow permissions. The change grants write access to repository contents, which may be required for certain workflow steps.