### PR TITLE
Hotfix: reset the .dockerignore 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,6 @@
 tmp/
 temp/
 
-# Ignore xml folder -- leave it to container 
-xml/
 
 # Ignore environment and secret files
 .env*


### PR DESCRIPTION
All 3 ELMO instances are down after merging of my branch.

The most likely reason for that is the following: 
I told container to ignore the /xml folder, and docker-entrypoint.sh changes the ownership of it: 
# give www-data ownership of the xml folder every start
chown -R www-data:www-data /var/www/html/xml

## Changes
[Welche Änderungen hast du hierfür vorgenommen?]

## Notes for Reviewer
[Beschreibung der notwendigen Testschritte]

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [ ] Ich habe selbst eine Code Review durchgeführt.
- [ ] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [ ] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [ ] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [ ] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [ ] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [ ] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [ ] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [ ] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [ ] Ich habe, wenn nötig die Playwright Tests aktualisiert und ggf. neue hinzugefügt
- [ ] Neue und bereits vorhandene automatisierte Playwright Tests werden im Pull Request bestanden
- [ ] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
Changing config files in feature branch is a very bad manner, Sasha....
