### PR TITLE
Chore: Deploy default EMLO under right subdomain

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -131,6 +131,7 @@ services:
       - "traefik.http.routers.elmo-gem-router.middlewares=elmo-gem-stripprefix"
       - "traefik.http.middlewares.elmo-gem-stripprefix.stripprefix.prefixes=/elmo-gem"
       - "traefik.http.services.elmo-gem-service.loadbalancer.server.port=80"
+      - "traefik.docker.network=traefik"
 
 volumes:
   db_data:


### PR DESCRIPTION
This pull request updates the production Traefik routing configuration to use the right subdomain for the `elmo` service.

## Changes
### Routing configuration update
* Changed the Traefik router rule in `docker-compose.prod.yml` to use the `dataservices.gfz.de` domain instead of `env.rz-vm182.gfz.de` for the `elmo` service.

## Notes for Reviewer
It is a very experimental try, but maybe it will work. Please let me merge it myselt, because i can revert the Commit if it will not work on production.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Playwright Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Playwright Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
- I will make ELMO-MSL in another PR if this is working.