### PR TITLE
Hotfix: SMTP error logging is propper

### DIFF
--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -162,15 +162,6 @@ try {
     // Send email with XML attachment
     $mail = new PHPMailer(true);
 
-    // Configure debugging
-    $debugging_output = '';
-    $mail->SMTPDebug = 2; // Enable verbose debug output
-    // Capture SMTP debug output for returning to the client while still logging it
-    $mail->Debugoutput = function ($str, $level) use (&$debugging_output) {
-        $debugging_output .= $str;
-        error_log($str);
-    };
-
     // Server settings for GFZ SMTP
     $mail->isSMTP();
     $mail->Host = $smtpHost; // Direct hostname for GFZ


### PR DESCRIPTION
solves [#758](https://github.com/McNamara84/elmo/issues/758)

removes sending the SMTP credentials to the log.

## Changes
Needed only to remove the problematic parts. there is already a safe logging implemented at line 299

## Notes for Reviewer


## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues

