### PR TITLE
fix: allowing comma in title input field

### DIFF
--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -113,7 +113,7 @@
             <div class="input-group has-validation">
               <div class="form-floating">
                 <input type="text" class="form-control input-with-help input-right-no-round-corners"
-                  id="input-resourceinformation-title" name="title[]" pattern="^[a-zA-ZäÄöÖ_ßüÜ0-9.\(\)\!\:\?\- ]+$"
+                  id="input-resourceinformation-title" name="title[]" pattern="^[a-zA-ZäÄöÖ_ßüÜ0-9.\,\(\)\!\:\?\- ]+$"
                   required />
                 <label for="input-resourceinformation-title">
                   <span data-translate="resourceInfo.resourceTitle"></span><span class="red-star">*</span>


### PR DESCRIPTION
In this pull request, the use of commas in the title field has been enabled.

#800

