### PR TITLE
Hotfix: ignore timezone if time is not provided

### DIFF
--- a/save/formgroups/save_spatialtemporalcoverage.php
+++ b/save/formgroups/save_spatialtemporalcoverage.php
@@ -73,6 +73,15 @@ function saveSpatialTemporalCoverage($connection, $postData, $resource_id)
  */
 function insertSpatialTemporalCoverage($connection, $stcData)
 {
+    // temporary measure before ERNIE implementation
+    // reason: the old editor can't handle Date+Timezone 
+    error_log("Starting stc insertion with data: " . print_r($stcData, true));
+    if ($stcData['timeStart'] === NULL || $stcData['timeEnd'] === NULL) {
+        error_log("Nullifying timezone due to missing timeStart or timeEnd");
+        $stcData['timezone'] = NULL;
+        error_log("Timezone after nullification: " . var_export($stcData['timezone'], true));
+    }
+    
     $stmt = $connection->prepare("INSERT INTO Spatial_Temporal_Coverage 
         (`latitudeMin`, `latitudeMax`, `longitudeMin`, `longitudeMax`, `description`, 
          `dateStart`, `dateEnd`, `timeStart`, `timeEnd`, `timezone`) 


### PR DESCRIPTION
## 💡 Fix: Legacy Timezone Compatibility

Entries with **Date + Timezone** are currently incompatible with the old editor. This must be fixed for smooth transitions. If neither `timeStart` nor `timeEnd` is provided, we must explicitly **nullify the timezone**. This simple change restores compatibility and ensures data integrity.

---

## Changes

In `save_script`, the timezone is now set to **NULL** when no time values are present. This prevents the conflict.

---

## Notes for Reviewer 🕵️

Logging is enabled. You can observe the code's behavior in the docker container logs.

---

## Checklist ✅
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.

---

## Known Issues 🐛
[None]