### PR TITLE
Hotfix: replace empty string with null for coalesce in STC

### DIFF
--- a/save/formgroups/save_spatialtemporalcoverage.php
+++ b/save/formgroups/save_spatialtemporalcoverage.php
@@ -31,16 +31,16 @@ function saveSpatialTemporalCoverage($connection, $postData, $resource_id)
     for ($i = 0; $i < $len; $i++) {
         // Extract data for easier handling
         $entry = [
-            'latitudeMin' => $postData['tscLatitudeMin'][$i] ?? '',
-            'latitudeMax' => $postData['tscLatitudeMax'][$i] ?? '',
-            'longitudeMin' => $postData['tscLongitudeMin'][$i] ?? '',
-            'longitudeMax' => $postData['tscLongitudeMax'][$i] ?? '',
-            'description' => $postData['tscDescription'][$i] ?? '',
-            'dateStart' => $postData['tscDateStart'][$i] ?? '',
-            'dateEnd' => $postData['tscDateEnd'][$i] ?? '',
-            'timeStart' => $postData['tscTimeStart'][$i] ?? '',
-            'timeEnd' => $postData['tscTimeEnd'][$i] ?? '',
-            'timezone' => $postData['tscTimezone'][$i] ?? ''
+            'latitudeMin' => $postData['tscLatitudeMin'][$i] ?? NULL, // Exception in saveSpatialTemporalCoverage: Incorrect double value: '' for column `elmocache`.`Spatial_Temporal_Coverage`.`latitudeMin` at row 1, referer: https://dataservices.gfz-potsdam.de/elmo
+            'latitudeMax' => $postData['tscLatitudeMax'][$i] ?? NULL,
+            'longitudeMin' => $postData['tscLongitudeMin'][$i] ?? NULL,
+            'longitudeMax' => $postData['tscLongitudeMax'][$i] ?? NULL,
+            'description' => $postData['tscDescription'][$i] ?? NULL,
+            'dateStart' => $postData['tscDateStart'][$i] ?? NULL,
+            'dateEnd' => $postData['tscDateEnd'][$i] ?? NULL,
+            'timeStart' => $postData['tscTimeStart'][$i] ?? NULL,
+            'timeEnd' => $postData['tscTimeEnd'][$i] ?? NULL,
+            'timezone' => $postData['tscTimezone'][$i] ?? NULL
         ];
 
         if (!validateSTCDependencies($entry)) {


### PR DESCRIPTION
[Briefly describe the changes and reference any related issues.]

## Changes
[What changes have you made?]

## Notes for Reviewer

I was able to reproduce the error in:

```
INSERT INTO `Spatial_Temporal_Coverage` 
(`latitudeMin`, `latitudeMax`, `longitudeMin`, `longitudeMax`, `description`) 
VALUES 
(NULL, NULL, NULL, NULL, NULL);
```
Was OK,

While this:

```
MariaDB [elmocache]> INSERT INTO `Spatial_Temporal_Coverage` 
    -> (`latitudeMin`, `latitudeMax`, `longitudeMin`, `longitudeMax`, `description`) 
    -> VALUES 
    -> ('', '', '', '', 'This entry was inserted with empty strings.');
ERROR 1366 (22007): Incorrect double value: '' for column `elmocache`.`Spatial_Temporal_Coverage`.`latitudeMin` at row 1
```
### Result was:
**ERROR 1366 (22007): Incorrect double value: '' for column `elmocache`.`Spatial_Temporal_Coverage`.`latitudeMin` at row 1**

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
