### PR TITLE
Hotfix: Remove pattern from person name fields

### DIFF
--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -33,7 +33,8 @@
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
-              <input type="text" class="form-control" id="input-author-lastname" name="familynames[]" required />
+              <input type="text" class="form-control" id="input-author-lastname" name="familynames[]" 
+              pattern="^[\p{L}\s'-]+$"  required />
               <label for="input-author-lastname"><span data-translate="general.lastName">Last Name</span><span
                   class="red-star">*</span></label>
               <div class="invalid-feedback" data-translate="general.lastNameInvalid">
@@ -46,7 +47,8 @@
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
-              <input type="text" class="form-control" id="input-author-firstname" name="givennames[]" required   />
+              <input type="text" class="form-control" id="input-author-firstname" name="givennames[]" 
+              pattern="^[\p{L}\s'-]+$"  required   />
               <label for="input-author-firstname"><span data-translate="general.firstName">First Name</span><span
                   class="red-star">*</span></label>
               <div class="invalid-feedback" data-translate="general.firstNameInvalid">

--- a/formgroups/contributorPersons.html
+++ b/formgroups/contributorPersons.html
@@ -27,7 +27,8 @@
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
-              <input type="text" class="form-control" id="input-contributor-lastname" name="cbPersonLastname[]"  />
+              <input type="text" class="form-control" id="input-contributor-lastname" pattern="^[\p{L}\s'-]+$" 
+              name="cbPersonLastname[]"  />
               <label for="input-contributor-lastname" data-translate="general.lastName">Last Name</label>
               <div class="invalid-feedback" data-translate="general.lastNameInvalid">Please provide a lastname. Only letters are allowed.</div>
             </div>
@@ -37,7 +38,8 @@
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
-              <input type="text" class="form-control" id="input-contributor-firstname" name="cbPersonFirstname[]"  />
+              <input type="text" class="form-control" id="input-contributor-firstname" pattern="^[\p{L}\s'-]+$" 
+              name="cbPersonFirstname[]"  />
               <label for="input-contributor-firstname" data-translate="general.firstName">First Name</label>
               <div class="invalid-feedback" data-translate="general.firstNameInvalid"></div>
             </div>


### PR DESCRIPTION
#856

This hotfix removes the previously applied pattern validation from person-related name fields.
The validation was blocking valid international names, which is not acceptable for users entering personal data.


## Known Issues
#860
