### PR TITLE
Testing: optimising footer links test

### DIFF
--- a/tests/playwright/features/footer.spec.ts
+++ b/tests/playwright/features/footer.spec.ts
@@ -43,33 +43,45 @@ test.describe('Footer Tests', () => {
     await elmoGuide.click();
   });
 
-  test('Verify footer buttons open correct links', async ({ page }) => {
+  test('Verify legal notice button opens correct link', async ({ page }) => {
     await page.goto('/');
-
+    
     const legalNoticeButton = page.locator('#buttonLegalNotice');
-    const privacyPolicyButton = page.locator('#buttonPrivacy');
-    const elmoGuideButton = page.locator('#buttonHelp');
-
-    const [legalNoticePage] = await Promise.all([
-      page.context().waitForEvent('page'),
-      legalNoticeButton.click(),
-    ]);
+    
+    const pagePromise = page.context().waitForEvent('page');
+    await legalNoticeButton.click();
+    const legalNoticePage = await pagePromise;
+    
+    await legalNoticePage.waitForLoadState('domcontentloaded');
     await expect(legalNoticePage).toHaveURL(/legal-notice/);
     await legalNoticePage.close();
-
-    const [privacyPolicyPage] = await Promise.all([
-      page.context().waitForEvent('page'),
-      privacyPolicyButton.click(),
-    ]);
-    await expect(privacyPolicyPage).toHaveURL(/privacyPolicy.html/);
-    await privacyPolicyPage.close(); 
-
-    const [elmoGuidePage] = await Promise.all([
-      page.context().waitForEvent('page'),
-      elmoGuideButton.click(),
-    ]);
-    await expect(elmoGuidePage).toHaveURL(/help\.php/);
-    await elmoGuidePage.close();
   });
 
-})
+  test('Verify privacy policy button opens correct link', async ({ page }) => {
+    await page.goto('/');
+    
+    const privacyPolicyButton = page.locator('#buttonPrivacy');
+    
+    const pagePromise = page.context().waitForEvent('page');
+    await privacyPolicyButton.click();
+    const privacyPolicyPage = await pagePromise;
+    
+    await privacyPolicyPage.waitForLoadState('domcontentloaded');
+    await expect(privacyPolicyPage).toHaveURL(/privacyPolicy.html/);
+    await privacyPolicyPage.close();
+  });
+
+  test('Verify ELMO guide button opens correct link', async ({ page }) => {
+    await page.goto('/');
+    
+    const elmoGuideButton = page.locator('#buttonHelp');
+    
+    const pagePromise = page.context().waitForEvent('page');
+    await elmoGuideButton.click();
+    const elmoGuidePage = await pagePromise;
+    
+    await elmoGuidePage.waitForLoadState('domcontentloaded');
+    await expect(elmoGuidePage).toHaveURL(/help\.php/);
+    await elmoGuidePage.close();
+  })
+});


### PR DESCRIPTION
Dear colleagues, 

this one is a really small tests aimed at a better performance of Playwright tests in the Github Actions environment. 

Testing if the new pages open correctly is resource dependent. This can be a problem for optimised cloud testing containers.

## Changes
The idea is to split the "footer buttons open correct links" test into 3 separate tests. The splits the promise -> await for each specific link, making it more reliable and flexible

## Notes for Reviewer
Not much to do here, just check the code quality and run playwright tests

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None
