### PR TITLE
Hotfix: Related work cannot be saved/submited in ELMO

### DIFF
--- a/save/formgroups/save_relatedwork.php
+++ b/save/formgroups/save_relatedwork.php
@@ -75,14 +75,15 @@ function saveRelatedWork($connection, $postData, $resource_id)
  *
  * @return int|null The found relation ID or null if not found.
  */
-function getRelationId(mysqli $connection, string $relationName): ?int
+function getRelationId(mysqli $connection, string $relationId): ?int
 {
-    $stmt = $connection->prepare("SELECT `relation_id` FROM `Relation` WHERE `name` = ?");
+    $stmt = $connection->prepare("SELECT `relation_id` FROM `Relation` WHERE `relation_id` = ?");
     if (!$stmt) {
         error_log("Failed to prepare statement for getRelationId: " . $connection->error);
         return null;
     }
-    $stmt->bind_param("s", $relationName);
+    $id = (int)$relationId;
+    $stmt->bind_param("i", $id);
     if (!$stmt->execute()) {
         error_log("Failed to execute statement for getRelationId: " . $stmt->error);
         $stmt->close();


### PR DESCRIPTION
This PR fixes the lookup of the Relation foreign key in the Related Work save logic so that the relation is now resolved by its database ID instead of its name, ensuring Related Work entries are correctly persisted and no longer cause transaction rollbacks.

## Problem description
If you fill out the form and also the “related work” form group, including all its fields, you can no longer save or submit.

## Changes
Updated `getRelationId()` to accept a relation ID from the form payload and query `Relation.relation_id` instead of `Relation.name`.

