### PR TITLE
Fix: null-saving mechanism for License

### DIFF
--- a/save/formgroups/save_resourceinformation_and_rights.php
+++ b/save/formgroups/save_resourceinformation_and_rights.php
@@ -36,10 +36,6 @@ function saveResourceInformationAndRights($connection, $postData)
             $requiredFields = ['year', 'dateCreated', 'resourcetype', 'language'];
             $requiredArrayFields = ['title', 'titleType'];
 
-            if ($showLicense) {
-                $requiredFields[] = 'Rights';
-            }
-
             if (!validateRequiredFields($postData, $requiredFields, $requiredArrayFields)) {
                 return false;
             }


### PR DESCRIPTION
In the file sent by K. it says:

`<b>Warning</b>:  Undefined array key "Rights" in <b>/var/www/html/save/formgroups/save_resourceinformation_and_rights.php</b> on line <b>115</b><br />`

Meaning that the code tried to access the data which is not in the postData. Why is it not in postData I can't tell you : (
 
So, the nullcheck was added and back-end validation relaxed to avoid such bugs in the future.

## Changes
[What changes have you made?]

## Notes for Reviewer
[Describe the steps needed to test this]

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
