### PR TITLE
Fix: change the names of the Author FGs

### DIFF
--- a/formgroups/authorInstitution.html
+++ b/formgroups/authorInstitution.html
@@ -1,5 +1,5 @@
 <div class="card mb-2">
-    <div class="card-header"><b data-translate="authorsInstitutions.title">Author Institution</b>
+    <div class="card-header"><b data-translate="authorsInstitutions.title">Author (Institutions)</b>
         <i class="bi bi-question-circle-fill" data-help-section-id="help-author-institution-fg"></i>
     </div>
     <div class="card-body">

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -1,5 +1,5 @@
 <div class="card mb-2">
-  <div class="card-header"><b data-translate="authors.title">Author(s)</b>
+  <div class="card-header"><b data-translate="authors.title">Author (Persons)</b>
     <i class="bi bi-question-circle-fill" data-help-section-id="help-authors-fg"></i>
   </div>
   <div class="card-body">


### PR DESCRIPTION
According to K. the 2 Author FGs should be named exactly as Contributor FGs:
- Author (Persons)
- Author (Institutions)
According to K. Authors Institutions is confusing: 

> "As if this Form group asks for affiliation." 

## Changes
Change the titles in the lang files.

## Notes for Reviewer


## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
