### PR TITLE
Fix: foreign key constraint resource-rights

### DIFF
--- a/save/formgroups/save_resourceinformation_and_rights.php
+++ b/save/formgroups/save_resourceinformation_and_rights.php
@@ -81,19 +81,33 @@ function saveResourceInformationAndRights($connection, $postData)
  */
 function prepareResourceData($postData)
 {
+    global $connection, $defaultLicense;
 
     $rightsId = null;
     
     // Try to get Rights from POST data
     if (isset($postData['Rights']) && !empty($postData['Rights'])) {
-        $rightsId = (int) $postData['Rights'];
-        // Validate that this rights_id actually exists
-        $stmt = $connection->prepare("SELECT rights_id FROM Rights WHERE rights_id = ?");
-        $stmt->bind_param("i", $rightsId);
-        $stmt->execute();
-        if ($stmt->get_result()->num_rows === 0) {
-            error_log("Invalid Rights ID provided: $rightsId. Falling back to default.");
+        try {
+            $rightsId = (int) $postData['Rights'];
+            // Check if casting resulted in 0 or invalid value
+            if ($rightsId <= 0) {
+                error_log("Rights value is not a valid positive integer: " . var_export($postData['Rights'], true));
+                $rightsId = null;
+            }
+        } catch (Exception $e) {
+            error_log("Failed to cast Rights to int: " . $e->getMessage() . ". Value: " . var_export($postData['Rights'], true));
             $rightsId = null;
+        }
+        
+        // Validate that this rights_id actually exists
+        if ($rightsId !== null) {
+            $stmt = $connection->prepare("SELECT rights_id FROM Rights WHERE rights_id = ?");
+            $stmt->bind_param("i", $rightsId);
+            $stmt->execute();
+            if ($stmt->get_result()->num_rows === 0) {
+                error_log("Invalid Rights ID provided: $rightsId. Falling back to default.");
+                $rightsId = null;
+            }
         }
     }
     


### PR DESCRIPTION
In the logs we read:

`Error in saveResourceInformationAndRights: Cannot add or update a child row: a foreign key constraint fails (`elmocache`.`Resource`, CONSTRAINT `Resource_ibfk_1` FOREIGN KEY (`Rights_rights_id`) REFERENCES `Rights` (`rights_id`)), referer: https://dataservices.gfz-potsdam.de/elmo`

this means, ELMO is trying to insert a Rights_rights_id, which does not exist in the Rights table. 
The reason for that can be a false type cast or that the licanse is not present in postData. 

## Changes
I have improved the logic in a database ingestion and set CC_BY_4 as a fallback option. 

## Notes for Reviewer
[Describe the steps needed to test this]

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
