### PR TITLE
ELMOGEM frontend: simplify the resource information

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -15,7 +15,7 @@
                 <ul>
                     <li><strong>Features:</strong>
                         <ul>
-                            
+                            <li>ICGEM version: simplified the Resource Information form group and set English as a default.</li>
                         </ul>
                     </li>
                     <li><strong>Fixes:</strong>

--- a/js/language.js
+++ b/js/language.js
@@ -206,6 +206,10 @@ $(document).ready(function () {
             changeLanguage(lang);
         }
     });
+        // Force English for GEM instances
+    if (window.ELMO_FEATURES?.showGGMsProperties) {
+        changeLanguage('en');
+    }
 });
 
 // Export for testing

--- a/js/select.js
+++ b/js/select.js
@@ -562,7 +562,7 @@ function populateTimezoneDropdownWithData(timezones) {
 function populateResourceTypeDropdownWithData(types) {
   const $select = $("#input-resourceinformation-resourcetype");
   if (!$select.length) return;
-  isGEM = window.ELMO_FEATURES?.showGGMsProperties
+  const isGEM = window.ELMO_FEATURES?.showGGMsProperties
   
   // Always empty to remove "Loading..." option
   $select.empty();
@@ -601,7 +601,7 @@ function populateLanguageDropdownWithData(languages) {
   const $select = $("#input-resourceinformation-language");
   if (!$select.length) return;
 
-  isGEM = window.ELMO_FEATURES?.showGGMsProperties 
+  const isGEM = window.ELMO_FEATURES?.showGGMsProperties 
   
   // Always empty to remove "Loading..." option
   $select.empty();

--- a/js/select.js
+++ b/js/select.js
@@ -157,19 +157,12 @@ function setupResourceTypeDropdown() {
     method: "GET",
     dataType: "json",
     success: function (data) {
-      select.empty().append(
-        $("<option>", {
-          value: "",
-          text: "Choose...",
-          "data-translate": "general.choose",
-        })
-      );
+      select.empty();
+      addPlaceholder(select, true);
 
       if (Array.isArray(data)) {
-        // Filter to only show "Dataset" if showGGMsProperties is enabled
-        const filteredData = window.ELMO_FEATURES?.showGGMsProperties 
-          ? data.filter(type => type.resource_type_general === "Dataset")
-          : data;
+        const isGEM = window.ELMO_FEATURES?.showGGMsProperties;
+        const filteredData = filterDataByGEM(data, 'resourceType', isGEM);
 
         filteredData.forEach(function (type) {
           select.append(
@@ -213,19 +206,12 @@ function setupLanguageDropdown() {
     method: "GET",
     dataType: "json",
     success: function (data) {
-      select.empty().append(
-        $("<option>", {
-          value: "",
-          text: "Choose...",
-          "data-translate": "general.choose",
-        })
-      );
+      select.empty();
+      addPlaceholder(select, true);
 
       if (Array.isArray(data)) {
-        // Filter to only show "English" if showGGMsProperties is enabled
-        const filteredData = window.ELMO_FEATURES?.showGGMsProperties 
-          ? data.filter(lang => lang.name === "English")
-          : data;
+        const isGEM = window.ELMO_FEATURES?.showGGMsProperties;
+        const filteredData = filterDataByGEM(data, 'language', isGEM);
 
         filteredData.forEach(function (lang) {
           select.append(
@@ -403,6 +389,45 @@ function setupLicenseDropdown(isSoftware) {
   });
 }
 
+/**
+ * Adds a "Choose..." placeholder option to a dropdown
+ * For ICGEM-specific dropdowns, skips placeholder when ICGEM mode is enabled
+ * @param {jQuery} $select - The jQuery select element
+ * @param {boolean} isGEMDropdown - Whether this is a ICGEM-specific dropdown (skips placeholder if ICGEM enabled)
+ */
+function addPlaceholder($select, isGEMDropdown = false) {
+  const isGEM = window.ELMO_FEATURES?.showGGMsProperties;
+  
+  // For GEM dropdowns, don't add placeholder when GEM is enabled. For others, always add.
+  if (isGEMDropdown && isGEM) return;
+  
+  $select.append(
+    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
+  );
+}
+
+/**
+ * Filters data based on GEM feature flag
+ * @param {Array} data - Array of data objects to filter
+ * @param {string} type - Type of filter: "resourceType" or "language"
+ * @param {boolean} isGEM - Whether ICGEM mode is enabled (see showGGMsProperties flag)
+ * @returns {Array} Filtered data array
+ */
+function filterDataByGEM(data, type, isGEM) {
+  if (!isGEM || !Array.isArray(data)) {
+    return data;
+  }
+
+  switch (type) {
+    case 'resourceType':
+      return data.filter(item => item.resource_type_general === "Dataset");
+    case 'language':
+      return data.filter(item => item.name === "English");
+    default:
+      return data;
+  }
+}
+
 // Make functions available globally (important for tests)
 window.setupLicenseDropdown = setupLicenseDropdown;
 window.setupLanguageDropdown = setupLanguageDropdown;
@@ -562,23 +587,17 @@ function populateTimezoneDropdownWithData(timezones) {
 function populateResourceTypeDropdownWithData(types) {
   const $select = $("#input-resourceinformation-resourcetype");
   if (!$select.length) return;
-  const isGEM = window.ELMO_FEATURES?.showGGMsProperties
-  
+    
   // Always empty to remove "Loading..." option
   $select.empty();
   
-  // Only add "Choose..." placeholder for non-GEM versions
-  if (!isGEM) {
-    $select.append(
-      $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-    );
-  }
+  // Handle placeholder logic
+  addPlaceholder($select, true);
   
   if (Array.isArray(types)) {
-    // Filter to only show "Dataset" if showGGMsProperties is enabled
-    const filteredData = isGEM
-      ? types.filter(type => type.resource_type_general === "Dataset")
-      : types;
+    // Filter data based on GEM flag
+    const isGEM = window.ELMO_FEATURES?.showGGMsProperties;
+    const filteredData = filterDataByGEM(types, 'resourceType', isGEM);
     
     filteredData.forEach(type => {
       $select.append(
@@ -600,24 +619,17 @@ function populateResourceTypeDropdownWithData(types) {
 function populateLanguageDropdownWithData(languages) {
   const $select = $("#input-resourceinformation-language");
   if (!$select.length) return;
-
-  const isGEM = window.ELMO_FEATURES?.showGGMsProperties 
   
   // Always empty to remove "Loading..." option
   $select.empty();
   
-  // Only add "Choose..." placeholder for non-GEM versions
-  if (!isGEM) {
-    $select.append(
-      $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-    );
-  }
+  // Handle placeholder logic
+  addPlaceholder($select, true);
   
   if (Array.isArray(languages)) {
-    // Filter to only show "English" if showGGMsProperties is enabled
-    const filteredData = isGEM
-      ? languages.filter(lang => lang.name === "English")
-      : languages;
+    // Filter data based on GEM flag
+    const isGEM = window.ELMO_FEATURES?.showGGMsProperties;
+    const filteredData = filterDataByGEM(languages, 'language', isGEM);
     
     filteredData.forEach(lang => {
       $select.append(
@@ -640,9 +652,8 @@ function populateTitleTypeDropdownWithData(types) {
   const $select = $("#input-resourceinformation-titletype");
   if (!$select.length) return;
 
-  $select.empty().append(
-    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-  );
+  $select.empty();
+  addPlaceholder($select);
 
   let mainTitleId = "";
 
@@ -708,9 +719,8 @@ function populateRelationsDropdownWithData(response) {
   const $select = $("#input-relatedwork-relation");
   if (!$select.length) return;
 
-  $select.empty().append(
-    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-  );
+  $select.empty();
+  addPlaceholder($select);
 
   if (response && response.relations && response.relations.length > 0) {
     response.relations
@@ -736,9 +746,8 @@ function populateIdentifierTypesDropdownWithData(response) {
   const $select = $("#input-relatedwork-identifiertype");
   if (!$select.length) return;
 
-  $select.empty().append(
-    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-  );
+  $select.empty();
+  addPlaceholder($select);
 
   if (response && response.identifierTypes) {
     response.identifierTypes.forEach(type => {
@@ -1111,6 +1120,8 @@ if (typeof module !== 'undefined' && module.exports) {
     populateLicenseDropdownWithData,
     populateRelationsDropdownWithData,
     populateIdentifierTypesDropdownWithData,
+    addPlaceholder,
+    filterDataByGEM,
     getIdentifierPriority,
     updateIdentifierType,
     debounce,

--- a/js/select.js
+++ b/js/select.js
@@ -491,7 +491,6 @@ function populateResourceTypeDropdownWithData(types) {
     const filteredData = isGEM
       ? types.filter(type => type.resource_type_general === "Dataset")
       : types;
-    console.log("Filtered resource types:", filteredData);
     
     filteredData.forEach(type => {
       $select.append(

--- a/js/select.js
+++ b/js/select.js
@@ -166,7 +166,12 @@ function setupResourceTypeDropdown() {
       );
 
       if (Array.isArray(data)) {
-        data.forEach(function (type) {
+        // Filter to only show "Dataset" if showGGMsProperties is enabled
+        const filteredData = window.ELMO_FEATURES?.showGGMsProperties 
+          ? data.filter(type => type.resource_type_general === "Dataset")
+          : data;
+
+        filteredData.forEach(function (type) {
           select.append(
             $("<option>", {
               value: type.id,
@@ -217,7 +222,12 @@ function setupLanguageDropdown() {
       );
 
       if (Array.isArray(data)) {
-        data.forEach(function (lang) {
+        // Filter to only show "English" if showGGMsProperties is enabled
+        const filteredData = window.ELMO_FEATURES?.showGGMsProperties 
+          ? data.filter(lang => lang.name === "English")
+          : data;
+
+        filteredData.forEach(function (lang) {
           select.append(
             $("<option>", {
               value: lang.id,
@@ -464,13 +474,26 @@ function populateTimezoneDropdownWithData(timezones) {
 function populateResourceTypeDropdownWithData(types) {
   const $select = $("#input-resourceinformation-resourcetype");
   if (!$select.length) return;
-
-  $select.empty().append(
-    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-  );
-
+  isGEM = window.ELMO_FEATURES?.showGGMsProperties
+  
+  // Always empty to remove "Loading..." option
+  $select.empty();
+  
+  // Only add "Choose..." placeholder for non-GEM versions
+  if (!isGEM) {
+    $select.append(
+      $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
+    );
+  }
+  
   if (Array.isArray(types)) {
-    types.forEach(type => {
+    // Filter to only show "Dataset" if showGGMsProperties is enabled
+    const filteredData = isGEM
+      ? types.filter(type => type.resource_type_general === "Dataset")
+      : types;
+    console.log("Filtered resource types:", filteredData);
+    
+    filteredData.forEach(type => {
       $select.append(
         $("<option>", {
           value: type.id,
@@ -491,12 +514,25 @@ function populateLanguageDropdownWithData(languages) {
   const $select = $("#input-resourceinformation-language");
   if (!$select.length) return;
 
-  $select.empty().append(
-    $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
-  );
-
+  isGEM = window.ELMO_FEATURES?.showGGMsProperties 
+  
+  // Always empty to remove "Loading..." option
+  $select.empty();
+  
+  // Only add "Choose..." placeholder for non-GEM versions
+  if (!isGEM) {
+    $select.append(
+      $("<option>", { value: "", text: "Choose...", "data-translate": "general.choose" })
+    );
+  }
+  
   if (Array.isArray(languages)) {
-    languages.forEach(lang => {
+    // Filter to only show "English" if showGGMsProperties is enabled
+    const filteredData = isGEM
+      ? languages.filter(lang => lang.name === "English")
+      : languages;
+    
+    filteredData.forEach(lang => {
       $select.append(
         $("<option>", {
           value: lang.id,


### PR DESCRIPTION
According to User feedback, too wide choice can be a bottleneck for an experienced scientist. 

## Changes
The resource types are limited to the only 1 applicable for ICGEM: Dataset
Language of the dataset is limited to: English
Language of the whole form is defaulted to: English.
   Reason: the German translation of the gravity-specific metadata is not good enough to showcase the ELMO-GEM


## Notes for Reviewer

- [ ] Check that only Dataset is available to choice as a resourceType 
- [ ] Check that the default language of the form is English, but other can be selected as well
- [ ] Check that only English is available as a language of a dataset

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
When we write Playwright tests, we shlould Not use selection of options from the dropdown list via the index. Only via the value. Indexes can vary, values is what we need.
