### PR TITLE
Hotfix: Debug the save_stc

### DIFF
--- a/save/formgroups/save_spatialtemporalcoverage.php
+++ b/save/formgroups/save_spatialtemporalcoverage.php
@@ -63,9 +63,10 @@ function saveSpatialTemporalCoverage($connection, $postData, $resource_id)
         $entry['latitudeMax']  = (trim($entry['latitudeMax'] ?? '') === '')  ? NULL : $entry['latitudeMax'];
         $entry['longitudeMin'] = (trim($entry['longitudeMin'] ?? '') === '') ? NULL : $entry['longitudeMin'];
         $entry['longitudeMax'] = (trim($entry['longitudeMax'] ?? '') === '') ? NULL : $entry['longitudeMax'];
+        $entry['dateStart'] = (trim($entry['dateStart'] ?? '') === '') ? NULL : $entry['dateStart'];
+        $entry['dateEnd'] = (trim($entry['dateEnd'] ?? '') === '') ? NULL : $entry['dateEnd'];
         $entry['timeStart'] = (trim($entry['timeStart'] ?? '') === '') ? NULL : $entry['timeStart'];
         $entry['timeEnd'] = (trim($entry['timeEnd'] ?? '') === '') ? NULL : $entry['timeEnd'];
-        $entry['dateEnd'] = (trim($entry['dateEnd'] ?? '') === '') ? NULL : $entry['dateEnd'];
         $entry['description'] = (trim($entry['description'] ?? '') === '') ? NULL : $entry['description'];
 
         // Save STC entry


### PR DESCRIPTION
Bugs were identified:

Providing spacial coverage and no datestart resulted in the rollback in save procedure. 
The validation was not entirely skipped for save_and_download scenario
The fast return was based on OR operator, not AND (If all entries are empty, nothing to save, return)
The nullifying of the observations before the database insert was incomplete.

The Bug hunt was motivated by #934 

## Changes
Fixed the abovelisted bugs.
Now User can save any subset of variables in the FG. 
User can submit if: Lattitudes and Longitudes are provided. If time start was added, time end must also be provided. 

## Notes for Reviewer
[Describe the steps needed to test this]

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
Possible intersections with Alis' work. But sorry, its a hotfix. 
