### PR TITLE
Hotfix: enable the save of titles.  

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -21,6 +21,7 @@
                     </li>
                     <li><strong>Fixes:</strong>
                         <ul>
+                            <li>Debugged Titles and Title Types in the Resource Information from group</li>
                         </ul>
                     </li>
                     <li><strong>Documentation:</strong>

--- a/install.php
+++ b/install.php
@@ -238,9 +238,9 @@ function createDatabaseStructure($connection): array
         "Title" => "CREATE TABLE IF NOT EXISTS `Title` (
     `title_id` INT NOT NULL AUTO_INCREMENT,
     `text` VARCHAR(256) NOT NULL,
-    `Title_Type_fk` INT NOT NULL,
+    `Title_Type_fk` INT NULL,
     `Resource_resource_id` INT NOT NULL,
-    PRIMARY KEY (`title_id`, `Title_Type_fk`, `Resource_resource_id`),
+    PRIMARY KEY (`title_id`),
     FOREIGN KEY (`Title_Type_fk`)
     REFERENCES `Title_Type` (`title_type_id`),
     FOREIGN KEY (`Resource_resource_id`)

--- a/save/formgroups/save_resourceinformation_and_rights.php
+++ b/save/formgroups/save_resourceinformation_and_rights.php
@@ -290,10 +290,10 @@ function isTitleTypeValid($connection, $title_type_id)
 /**
  * Saves titles for a resource, handling duplicates.
  * Allows saving:
- * - Titles with text only (titleType can be empty/NULL)
  * - Titles with both text and titleType
  *
  * Will SKIP without a failure:
+ * - Titles with text only (type must be present)
  * - Titles with titleType only (text must be present if type is present)
  * - Entirely empty entries (both text and type are empty)
  *
@@ -320,64 +320,54 @@ function saveTitles($connection, $resource_id, $titles, $titleTypes)
             continue;
         }
         
-        // Skip if type is present but text is empty (type without text is not allowed)
-        if (empty($title_text) && !empty($title_type_str)) {
-            error_log("Skipping title entry at index $i: type is present ('$title_type_str') but text is empty. Title text is required when title type is specified.");
+        // Skip if text is empty (text is required)
+        if (empty($title_text)) {
+            error_log("Skipping title entry at index $i: text is empty. Title text is required.");
+            continue;
+        }
+        
+        // Skip if type is empty (type is required)
+        if (empty($title_type_str)) {
+            error_log("Skipping title entry at index $i: type is empty. Title type is required.");
             continue;
         }
         
         // Convert title_type string to integer if present
-        $title_type_int = null;
-        if (!empty($title_type_str)) {
-            $title_type_int = intval($title_type_str);
-            
-            // Validate the title type exists in the database
-            if (!isTitleTypeValid($connection, $title_type_int)) {
-                error_log("Invalid title type at index $i. Type ID '$title_type_int' does not exist in Title_Type table. Skipping.");
-                continue;
-            }
+        $title_type_int = intval($title_type_str);
+        
+        // Validate the title type exists in the database
+        if (!isTitleTypeValid($connection, $title_type_int)) {
+            error_log("Invalid title type at index $i. Type ID '$title_type_int' does not exist in Title_Type table. Skipping.");
+            continue;
         }
         
         // Create unique key for deduplication
-        $key = $title_text . '|' . ($title_type_int ?? 'NULL');
+        $key = $title_text . '|' . $title_type_int;
         if (!isset($uniqueTitles[$key])) {
             $uniqueTitles[$key] = [
                 'text' => $title_text,
                 'type' => $title_type_int
             ];
-            error_log("Added title to save: text='$title_text', type=" . ($title_type_int ?? 'NULL'));
+            error_log("Added title to save: text='$title_text', type=$title_type_int");
         }
     }
 
     foreach ($uniqueTitles as $title) {
-        if ($title['type'] === null) {
-            // Insert title without type (type will be NULL)
-            $stmt = $connection->prepare("INSERT INTO Title 
-                (`text`, `Title_Type_fk`, `Resource_resource_id`) 
-                VALUES (?, NULL, ?)");
-            $stmt->bind_param(
-                "si",
-                $title['text'],
-                $resource_id
-            );
-        } else {
-            // Insert title with type as integer
-            $stmt = $connection->prepare("INSERT INTO Title 
-                (`text`, `Title_Type_fk`, `Resource_resource_id`) 
-                VALUES (?, ?, ?)");
-            $stmt->bind_param(
-                "sii",
-                $title['text'],
-                $title['type'],
-                $resource_id
-            );
-        }
+        $stmt = $connection->prepare("INSERT INTO Title 
+            (`text`, `Title_Type_fk`, `Resource_resource_id`) 
+            VALUES (?, ?, ?)");
+        $stmt->bind_param(
+            "sii",
+            $title['text'],
+            $title['type'],
+            $resource_id
+        );
         
         if (!$stmt->execute()) {
             error_log("Failed to insert title: " . $stmt->error);
             return false;
         }
-        error_log("Successfully inserted title: text='" . $title['text'] . "', type=" . ($title['type'] ?? 'NULL'));
+        error_log("Successfully inserted title: text='" . $title['text'] . "', type=" . $title['type']);
     }
 
     return true;

--- a/save/formgroups/save_resourceinformation_and_rights.php
+++ b/save/formgroups/save_resourceinformation_and_rights.php
@@ -267,12 +267,42 @@ function createNewResource($connection, $resourceData)
 }
 
 /**
+ * Validates that a title type ID exists in the database.
+ *
+ * @param mysqli $connection The database connection
+ * @param int $title_type_id The title type ID to validate
+ * @return bool True if the title type exists, false otherwise
+ */
+function isTitleTypeValid($connection, $title_type_id)
+{
+    if ($title_type_id === null || $title_type_id <= 0) {
+        return false;
+    }
+    
+    $stmt = $connection->prepare("SELECT title_type_id FROM Title_Type WHERE title_type_id = ?");
+    $stmt->bind_param("i", $title_type_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    
+    return $result->num_rows > 0;
+}
+
+/**
  * Saves titles for a resource, handling duplicates.
+ * Allows saving:
+ * - Titles with text only (titleType can be empty/NULL)
+ * - Titles with both text and titleType
+ *
+ * Will SKIP without a failure:
+ * - Titles with titleType only (text must be present if type is present)
+ * - Entirely empty entries (both text and type are empty)
+ *
+ * Title types are validated against the Title_Type table in the database.
  *
  * @param mysqli $connection The database connection
  * @param int $resource_id The resource ID
  * @param array $titles Array of titles
- * @param array $titleTypes Array of title types
+ * @param array $titleTypes Array of title types (as integers from form)
  * @return bool True if successful, false otherwise
  */
 function saveTitles($connection, $resource_id, $titles, $titleTypes)
@@ -281,30 +311,73 @@ function saveTitles($connection, $resource_id, $titles, $titleTypes)
     
     $uniqueTitles = [];
     for ($i = 0; $i < count($titles); $i++) {
-        $key = $titles[$i] . '|' . $titleTypes[$i];
+        $title_text = isset($titles[$i]) ? trim($titles[$i]) : '';
+        $title_type_str = isset($titleTypes[$i]) ? trim($titleTypes[$i]) : '';
+        
+        // Skip entirely empty entries (both text and type are empty)
+        if (empty($title_text) && empty($title_type_str)) {
+            error_log("Skipping completely empty title entry at index $i");
+            continue;
+        }
+        
+        // Skip if type is present but text is empty (type without text is not allowed)
+        if (empty($title_text) && !empty($title_type_str)) {
+            error_log("Skipping title entry at index $i: type is present ('$title_type_str') but text is empty. Title text is required when title type is specified.");
+            continue;
+        }
+        
+        // Convert title_type string to integer if present
+        $title_type_int = null;
+        if (!empty($title_type_str)) {
+            $title_type_int = intval($title_type_str);
+            
+            // Validate the title type exists in the database
+            if (!isTitleTypeValid($connection, $title_type_int)) {
+                error_log("Invalid title type at index $i. Type ID '$title_type_int' does not exist in Title_Type table. Skipping.");
+                continue;
+            }
+        }
+        
+        // Create unique key for deduplication
+        $key = $title_text . '|' . ($title_type_int ?? 'NULL');
         if (!isset($uniqueTitles[$key])) {
             $uniqueTitles[$key] = [
-                'text' => $titles[$i],
-                'type' => $titleTypes[$i]
+                'text' => $title_text,
+                'type' => $title_type_int
             ];
+            error_log("Added title to save: text='$title_text', type=" . ($title_type_int ?? 'NULL'));
         }
     }
 
     foreach ($uniqueTitles as $title) {
-        $stmt = $connection->prepare("INSERT INTO Title 
-            (`text`, `Title_Type_fk`, `Resource_resource_id`) 
-            VALUES (?, ?, ?)");
-        $stmt->bind_param(
-            "sii",
-            $title['text'],
-            $title['type'],
-            $resource_id
-        );
+        if ($title['type'] === null) {
+            // Insert title without type (type will be NULL)
+            $stmt = $connection->prepare("INSERT INTO Title 
+                (`text`, `Title_Type_fk`, `Resource_resource_id`) 
+                VALUES (?, NULL, ?)");
+            $stmt->bind_param(
+                "si",
+                $title['text'],
+                $resource_id
+            );
+        } else {
+            // Insert title with type as integer
+            $stmt = $connection->prepare("INSERT INTO Title 
+                (`text`, `Title_Type_fk`, `Resource_resource_id`) 
+                VALUES (?, ?, ?)");
+            $stmt->bind_param(
+                "sii",
+                $title['text'],
+                $title['type'],
+                $resource_id
+            );
+        }
+        
         if (!$stmt->execute()) {
             error_log("Failed to insert title: " . $stmt->error);
             return false;
         }
-        error_log("Successfully inserted title: " . $title['text']);
+        error_log("Successfully inserted title: text='" . $title['text'] . "', type=" . ($title['type'] ?? 'NULL'));
     }
 
     return true;

--- a/tests/SaveResourceInformationAndRightsTest.php
+++ b/tests/SaveResourceInformationAndRightsTest.php
@@ -510,7 +510,7 @@ class SaveResourceInformationAndRightsTest extends DatabaseTestCase
     }
 
     /**
-     * Tests saving a title with text only, without a title type (NULL).
+     * Tests that a title with text only (without type) is skipped, not saved.
      * 
      * @return void
      */
@@ -532,18 +532,8 @@ class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         ];
 
         $resource_id = saveResourceInformationAndRights($this->connection, $postData);
-        $this->assertIsInt($resource_id, "Should return a valid resource ID");
-        $this->assertGreaterThan(0, $resource_id);
-
-        // Verify title was saved with NULL type
-        $stmt = $this->connection->prepare("SELECT * FROM Title WHERE Resource_resource_id = ?");
-        $stmt->bind_param("i", $resource_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $row = $result->fetch_assoc();
-
-        $this->assertEquals("Title Without Type", $row["text"], "Title text should be saved");
-        $this->assertNull($row["Title_Type_fk"], "Title type should be NULL when not provided");
+        // Should return false because title without type is skipped, no valid titles remain
+        $this->assertFalse($resource_id, "Should return false when title has no type (text-only titles not allowed)");
     }
 
     /**
@@ -606,15 +596,8 @@ class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         ];
 
         $resource_id = saveResourceInformationAndRights($this->connection, $postData);
-        $this->assertIsInt($resource_id, "Should still return a valid resource ID");
-
-        // Verify NO title was saved (entry should be skipped)
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Title WHERE Resource_resource_id = ?");
-        $stmt->bind_param("i", $resource_id);
-        $stmt->execute();
-        $count = $stmt->get_result()->fetch_assoc()['count'];
-
-        $this->assertEquals(0, $count, "Title with type but no text should be skipped (not saved)");
+        // Should return false because type without text is invalid, no valid titles remain
+        $this->assertFalse($resource_id, "Should return false when title has type but no text");
     }
 
     /**
@@ -669,5 +652,61 @@ class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         $resource_id = saveResourceInformationAndRights($this->connection, $postData);
         // Should return false because invalid type is skipped and no valid titles remain
         $this->assertFalse($resource_id, "Should return false when title type ID doesn't exist in database");
+    }
+
+    /**
+     * Tests mixed title scenarios: some valid, some invalid.
+     * Valid titles should be saved, invalid ones skipped.
+     * 
+     * @return void
+     */
+    public function testMixedTitlesWithSomeValid()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.MIXED.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => [
+                "Valid Title 1",      // Valid
+                "",                   // Invalid (no text)
+                "Valid Title 2",      // Valid
+                "Invalid No Type"     // Invalid (no type)
+            ],
+            "titleType" => [
+                "1",  // Valid type
+                "1",  // Invalid (no text to go with)
+                "2",  // Valid type
+                ""    // Invalid (no type)
+            ]
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        $this->assertIsInt($resource_id, "Should return a valid resource ID");
+        $this->assertGreaterThan(0, $resource_id);
+
+        // Verify only valid titles were saved
+        $stmt = $this->connection->prepare("SELECT * FROM Title WHERE Resource_resource_id = ? ORDER BY title_id");
+        $stmt->bind_param("i", $resource_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $this->assertEquals(2, $result->num_rows, "Should have exactly 2 valid titles saved");
+
+        $titles = [];
+        while ($row = $result->fetch_assoc()) {
+            $titles[] = $row;
+        }
+
+        $this->assertEquals("Valid Title 1", $titles[0]["text"], "First valid title should be saved");
+        $this->assertEquals(2, $titles[0]["Title_Type_fk"], "First valid title should have type 2");
+        $this->assertEquals("Valid Title 2", $titles[1]["text"], "Second valid title should be saved");
+        $this->assertEquals(2, $titles[1]["Title_Type_fk"], "Second valid title should have type 2");
     }
 }

--- a/tests/SaveResourceInformationAndRightsTest.php
+++ b/tests/SaveResourceInformationAndRightsTest.php
@@ -508,4 +508,166 @@ class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         $total_count = $stmt->get_result()->fetch_assoc()['count'];
         $this->assertEquals(5, $total_count, "Should have five datasets in total");
     }
+
+    /**
+     * Tests saving a title with text only, without a title type (NULL).
+     * 
+     * @return void
+     */
+    public function testTitleWithTextOnlyNullType()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.NULL.TYPE.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Title Without Type"],
+            "titleType" => [""]  // Empty title type
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        $this->assertIsInt($resource_id, "Should return a valid resource ID");
+        $this->assertGreaterThan(0, $resource_id);
+
+        // Verify title was saved with NULL type
+        $stmt = $this->connection->prepare("SELECT * FROM Title WHERE Resource_resource_id = ?");
+        $stmt->bind_param("i", $resource_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $row = $result->fetch_assoc();
+
+        $this->assertEquals("Title Without Type", $row["text"], "Title text should be saved");
+        $this->assertNull($row["Title_Type_fk"], "Title type should be NULL when not provided");
+    }
+
+    /**
+     * Tests saving a title with both text and a valid type.
+     * 
+     * @return void
+     */
+    public function testTitleWithTextAndValidType()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.VALID.TYPE.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Title With Valid Type"],
+            "titleType" => ["1"]  // Valid type ID
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        $this->assertIsInt($resource_id, "Should return a valid resource ID");
+        $this->assertGreaterThan(0, $resource_id);
+
+        // Verify title was saved with correct type
+        $stmt = $this->connection->prepare("SELECT * FROM Title WHERE Resource_resource_id = ?");
+        $stmt->bind_param("i", $resource_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $row = $result->fetch_assoc();
+
+        $this->assertEquals("Title With Valid Type", $row["text"], "Title text should be saved");
+        $this->assertEquals(1, $row["Title_Type_fk"], "Title type should be saved as integer 1");
+    }
+
+    /**
+     * Tests that a title with type but no text is skipped (not saved).
+     * 
+     * @return void
+     */
+    public function testTitleWithTypeButNoText()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.TYPE.NO.TEXT.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => [""],  // Empty title text
+            "titleType" => ["1"]  // Type without text
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        $this->assertIsInt($resource_id, "Should still return a valid resource ID");
+
+        // Verify NO title was saved (entry should be skipped)
+        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Title WHERE Resource_resource_id = ?");
+        $stmt->bind_param("i", $resource_id);
+        $stmt->execute();
+        $count = $stmt->get_result()->fetch_assoc()['count'];
+
+        $this->assertEquals(0, $count, "Title with type but no text should be skipped (not saved)");
+    }
+
+    /**
+     * Tests that completely empty title entries are skipped.
+     * 
+     * @return void
+     */
+    public function testCompletelyEmptyTitleEntry()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.EMPTY.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => [""],  // Empty title text
+            "titleType" => [""]  // Empty title type
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        // Should return false because there are no valid titles for a resource
+        $this->assertFalse($resource_id, "Should return false when all titles are empty");
+    }
+
+    /**
+     * Tests that invalid title type IDs are skipped with logging.
+     * 
+     * @return void
+     */
+    public function testInvalidTitleTypeId()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        $postData = [
+            "doi" => "10.5880/GFZ.TITLE.INVALID.TYPE.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Title With Invalid Type"],
+            "titleType" => ["9999"]  // Non-existent type ID
+        ];
+
+        $resource_id = saveResourceInformationAndRights($this->connection, $postData);
+        // Should return false because invalid type is skipped and no valid titles remain
+        $this->assertFalse($resource_id, "Should return false when title type ID doesn't exist in database");
+    }
 }


### PR DESCRIPTION
While testing the code I found that a title without a type entered nearby blocks the save operation.  

The new policy is to save titles, if there is no type 

# Changes
## Database Schema (`install.php`)

### Title_Type_fk Changes
- **Made nullable**: Changed from `INT NOT NULL` to `INT NULL` to allow titles without a type
- **Removed from PRIMARY KEY**: Changed composite key `(title_id, Title_Type_fk, Resource_resource_id)` to single primary key `(title_id)`
  - Primary keys cannot contain NULL values in MySQL, so the column had to be removed from the key definition
  - `title_id` is sufficient as a unique identifier for each title row

## Title Save Logic (`save_resourceinformation_and_rights.php`)

### New Validation Rules
- ✅ **Allow**: Titles with text only (type will be NULL)
- ✅ **Allow**: Titles with both text and type
- ❌ **Skip**: Titles with type but no text (type without text is meaningless)
- ❌ **Skip**: Completely empty entries (both text and type empty)

### Type Validation
- Title type IDs are converted from string to integer using `intval()`
- Title type IDs are validated against the `Title_Type` table before insertion
- Invalid type IDs are skipped with detailed logging (no database error)

### Database Insertion
Two separate prepared statements handle the NULL case correctly:
- **With type**: `INSERT INTO Title VALUES (?, ?, ?)` with type bound as integer
- **Without type**: `INSERT INTO Title VALUES (?, NULL, ?)` with hardcoded NULL in SQL

## Benefits
- **More flexible data entry** - Users can add titles without selecting a type
- **No foreign key violations** - NULL type IDs no longer cause constraint errors
- **Graceful error handling** - Invalid types are logged and skipped, not inserted
- **Works for both actions** - "save_and_download" and "submit" actions both benefit

## DataCite

Datacite can have only 1 title without tytle type. So in this case we shouldn't see the "fake" title:
<img width="1456" height="316" alt="Bildschirmfoto 2026-02-12 um 09 40 22" src="https://github.com/user-attachments/assets/a0b00d9e-b711-4347-b4d6-90081e4eadef" />

The XML output is:

```
  <titles>
    <title xml:lang="en">real title</title>
    <title titleType="TranslatedTitle">der übersetzter Titel</title>
  </titles>
```

## Notes for Reviewer
Testing steps:
<img width="1528" height="328" alt="Bildschirmfoto 2026-02-11 um 17 14 22" src="https://github.com/user-attachments/assets/36cd4173-a841-41d4-a969-ebe73b0ce861" />
works for me : )
## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
