### PR TITLE
hotfix: Fix visible JavaScript comment in footer

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -71,7 +71,7 @@ window.ELMO_FEATURES = {
 };
 </script>
 
-// Expose "isNewRecord" so JS can apply behavior only for new records
+<!-- Expose "isNewRecord" so JS can apply behavior only for new records -->
 <script>
   window.elmo = window.elmo || {};
   window.elmo.isNewRecord = <?php echo !empty($isNewRecord) && $isNewRecord ? 'true' : 'false'; ?>;


### PR DESCRIPTION
This PR fixes a visible inline JavaScript comment in the footer.

<img width="1218" height="213" alt="image" src="https://github.com/user-attachments/assets/cdd61fc9-1ebc-48f2-a93d-e88a2eeb6822" />


## Notes for Reviewer
Make sure there is no comment text visible below the footer.

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
