### PR TITLE
Fix: inclusion of save files in send_xml for ELMOGEM

### DIFF
--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -50,7 +50,10 @@ require_once __DIR__ . '/save/formgroups/save_usedinstruments.php';
 require_once __DIR__ . '/save/formgroups/save_fundingreferences.php';
 
 if ($showGGMsProperties) {
-    require_once __DIR__ . '/save/formgroups/save_ggmsproperties.php';
+    require_once __DIR__ . '/save/formgroups/save_ggms_properties.php';
+    require_once __DIR__ . '/save/formgroups/save_ggms_definition.php';
+    require_once __DIR__ . '/save/formgroups/save_ggms_modeltypes.php';
+    require_once __DIR__ . '/save/formgroups/save_ggms_datasources.php';
 }
 
 error_log("send_xml_file.php: Save functions included");


### PR DESCRIPTION
save files for elmogem are prefixed `save_ggms_`. Time to apply this for xml sending

## Changes
changed the require_once statements for ELMOGEM

## Notes for Reviewer
Please check if the new statements match the filename

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
save_data.php and send_xml_file.php do very similar things without interacting with eachother -- boilerplate code. 
