### PR TITLE
Chore: local compose file: LOCAL_DEVELOPMENT: "true"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       SHOW_USED_INSTRUMENTS: "true"
       SIMULATE_EMAIL: "true"
       API_BASE_URL: ${API_BASE_URL:-http://localhost:8080}
+      LOCAL_DEVELOPMENT: "true"
     depends_on:
       - db
     restart: unless-stopped


### PR DESCRIPTION
1 line change: added `LOCAL_DEVELOPMENT: "true" ` to the docker-compose.yaml.


This will prevent re-creating seettings.php every time. In the local development workflow. 

