### PR TITLE
Fix: enabled saving with an empty title

### DIFF
--- a/save/formgroups/save_resourceinformation_and_rights.php
+++ b/save/formgroups/save_resourceinformation_and_rights.php
@@ -2,14 +2,15 @@
 require_once dirname(__FILE__) . '/../validation.php';
 
 /**
- * Saves or updates resource information and rights in the database.
+ * Creates a new resource information and rights entry in the database.
  *
- * If a record with the same DOI exists, it updates the existing record.
- * For records without DOI, it creates a new entry with a NEW Resource ID.
- * Duplicate titles are only saved once.
+ * Always creates a new Resource entry with a new Resource ID.
+ * Duplicate titles are deduplicated within the same resource.
+ * Titles are only validated on submit action; save_and_download allows partial data.
  *
  * @param mysqli $connection The database connection
  * @param array  $postData   The POST data from the form containing:
+ *                          - action (string): Either 'submit' or 'save_and_download'
  *                          - doi (string|null): The DOI of the resource
  *                          - year (int): Publication year
  *                          - dateCreated (string): Creation date
@@ -21,7 +22,7 @@ require_once dirname(__FILE__) . '/../validation.php';
  *                          - title (array): Array of titles
  *                          - titleType (array): Array of title types
  *
- * @return int|false The ID of the created/updated resource or false if validation fails
+ * @return int|false The ID of the newly created resource or false if validation fails
  * @throws mysqli_sql_exception If a database error occurs
  */
 function saveResourceInformationAndRights($connection, $postData)
@@ -47,21 +48,10 @@ function saveResourceInformationAndRights($connection, $postData)
 
         // Sanitize and prepare data
         $resourceData = prepareResourceData($postData);
-
-
-        // Check for existing DOI and handle accordingly
-        $resource_id = handleExistingResource($connection, $resourceData);
-        if ($resource_id === false) {
-            // Create new resource if no existing one was found/updated
-            $resource_id = createNewResource($connection, $resourceData);
-        }
-
-        // IMPORTANT: Always save titles after resource is created/updated
-        if (!$resource_id) {
-            return false;
-        }
-        
-        if (!saveTitles($connection, $resource_id, $postData['title'], $postData['titleType'])) {
+        // Create new resource 
+        $resource_id = createNewResource($connection, $resourceData);
+        // Save titles after resource is created
+        if (!saveTitles($connection, $resource_id, $postData['title'], $postData['titleType'], $action)) {
             return false;
         }
 
@@ -152,87 +142,6 @@ function prepareResourceData($postData)
 }
 
 /**
- * Handles existing resources, updating them if found.
- * Cleans up all related entries before update.
- *
- * @param mysqli $connection The database connection
- * @param array $resourceData The prepared resource data
- * @return int|false Resource ID if updated, false if no existing resource found
- */
-function handleExistingResource($connection, $resourceData)
-{
-    if (empty($resourceData['doi'])) {
-        return false;
-    }
-
-    $stmt = $connection->prepare("SELECT resource_id FROM Resource WHERE doi = ?");
-    $stmt->bind_param("s", $resourceData['doi']);
-    $stmt->execute();
-    $result = $stmt->get_result();
-
-    if ($result->num_rows === 0) {
-        return false;
-    }
-
-    $row = $result->fetch_assoc();
-    $resource_id = $row['resource_id'];
-
-    // Delete entries from tables with direct resource_id reference
-    $directTables = [
-        'Description' => 'resource_id',  // Table name => column name
-        'Title' => 'Resource_resource_id'
-    ];
-
-    foreach ($directTables as $table => $columnName) {
-        $stmt = $connection->prepare("DELETE FROM " . $table . " WHERE " . $columnName . " = ?");
-        $stmt->bind_param("i", $resource_id);
-        $stmt->execute();
-    }
-
-    // Delete entries from relationship tables
-    $relationTables = [
-        'Resource_has_Author',
-        'Resource_has_Contributor_Person',
-        'Resource_has_Contributor_Institution',
-        'Resource_has_Contact_Person',
-        'Resource_has_Funding_Reference',
-        'Resource_has_Originating_Laboratory',
-        'Resource_has_Related_Work',
-        'Resource_has_Spatial_Temporal_Coverage',
-        'Resource_has_Thesaurus_Keywords',
-        'Resource_has_Free_Keywords'
-    ];
-
-    foreach ($relationTables as $table) {
-        $stmt = $connection->prepare("DELETE FROM " . $table . " WHERE Resource_resource_id = ?");
-        $stmt->bind_param("i", $resource_id);
-        $stmt->execute();
-    }
-
-    // Update existing resource
-    $stmt = $connection->prepare("UPDATE Resource SET 
-        version = ?, year = ?, dateCreated = ?, dateEmbargoUntil = ?,
-        Rights_rights_id = ?, Resource_Type_resource_name_id = ?, Language_language_id = ?
-        WHERE resource_id = ?");
-
-    $stmt->bind_param(
-        "dissiiii",
-        $resourceData['version'],
-        $resourceData['year'],
-        $resourceData['dateCreated'],
-        $resourceData['dateEmbargoUntil'],
-        $resourceData['rights'],
-        $resourceData['resourceType'],
-        $resourceData['language'],
-        $resource_id
-    );
-
-    $stmt->execute();
-
-    return $resource_id;
-}
-
-/**
  * Creates a new resource in the database.
  *
  * @param mysqli $connection The database connection
@@ -305,7 +214,7 @@ function isTitleTypeValid($connection, $title_type_id)
  * @param array $titleTypes Array of title types (as integers from form)
  * @return bool True if successful, false otherwise
  */
-function saveTitles($connection, $resource_id, $titles, $titleTypes)
+function saveTitles($connection, $resource_id, $titles, $titleTypes, $action = 'save_and_download')
 {
     error_log("saveTitles called with resource_id: $resource_id, title count: " . count($titles));
     
@@ -335,8 +244,8 @@ function saveTitles($connection, $resource_id, $titles, $titleTypes)
         // Convert title_type string to integer if present
         $title_type_int = intval($title_type_str);
         
-        // Validate the title type exists in the database
-        if (!isTitleTypeValid($connection, $title_type_int)) {
+        // (only for submit action): Validate the title type exists in the database
+        if ($action === 'submit' && !isTitleTypeValid($connection, $title_type_int)) {
             error_log("Invalid title type at index $i. Type ID '$title_type_int' does not exist in Title_Type table. Skipping.");
             continue;
         }
@@ -354,7 +263,7 @@ function saveTitles($connection, $resource_id, $titles, $titleTypes)
 
     if (empty($uniqueTitles)) {
         error_log("No valid titles to save");
-        return false;
+        return $action !== 'submit';
     }
 
     foreach ($uniqueTitles as $title) {

--- a/tests/SaveResourceInformationAndRightsTest.php
+++ b/tests/SaveResourceInformationAndRightsTest.php
@@ -232,76 +232,7 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         }
     }
 
-    /**
-     * Tests the update functionality when saving a resource with an existing DOI.
-     * 
-     * @return void
-     */
-    public function testUpdateExistingResource()
-    {
-        if (!function_exists('saveResourceInformationAndRights')) {
-            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
-        }
 
-        // Initial data
-        $initialData = [
-            "doi" => "10.5880/GFZ.UPDATE.TEST",
-            "year" => 2023,
-            "dateCreated" => "2023-06-01",
-            "resourcetype" => 1,
-            "version" => 1.0,
-            "language" => 1,
-            "Rights" => 1,
-            "title" => ["Original Title"],
-            "titleType" => [1]
-        ];
-
-        // Save initial resource
-        $first_resource_id = saveResourceInformationAndRights($this->connection, $initialData);
-        $this->assertIsInt($first_resource_id, "Initial save should return a valid resource ID");
-
-        // Updated data with same DOI but different values
-        $updatedData = [
-            "doi" => "10.5880/GFZ.UPDATE.TEST",
-            "year" => 2024,
-            "dateCreated" => "2024-01-01",
-            "resourcetype" => 2,
-            "version" => 2.0,
-            "language" => 2,
-            "Rights" => 2,
-            "title" => ["Updated Title"],
-            "titleType" => [1]
-        ];
-
-        // Save updated resource
-        $updated_resource_id = saveResourceInformationAndRights($this->connection, $updatedData);
-
-        // Should return the same resource ID
-        $this->assertEquals($first_resource_id, $updated_resource_id, "Update should return the same resource ID");
-
-        // Verify updated values
-        $stmt = $this->connection->prepare("SELECT * FROM Resource WHERE resource_id = ?");
-        $stmt->bind_param("i", $updated_resource_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $row = $result->fetch_assoc();
-
-        $this->assertEquals($updatedData["year"], $row["year"]);
-        $this->assertEquals($updatedData["dateCreated"], $row["dateCreated"]);
-        $this->assertEquals($updatedData["resourcetype"], $row["Resource_Type_resource_name_id"]);
-        $this->assertEquals($updatedData["version"], $row["version"]);
-        $this->assertEquals($updatedData["language"], $row["Language_language_id"]);
-        $this->assertEquals($updatedData["Rights"], $row["Rights_rights_id"]);
-
-        // Verify updated title
-        $stmt = $this->connection->prepare("SELECT * FROM Title WHERE Resource_resource_id = ?");
-        $stmt->bind_param("i", $updated_resource_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $row = $result->fetch_assoc();
-
-        $this->assertEquals($updatedData["title"][0], $row["text"]);
-    }
 
     /**
      * Tests saving multiple resources without DOIs.
@@ -404,112 +335,7 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         $this->assertEquals(2, $titles[1]['Title_Type_fk'], "Der zweite Titel sollte den Typ 2 haben");
     }
 
-    /**
-     * Tests handling of DOIs: updating existing DOIs and allowing multiple empty/null DOIs
-     * 
-     * @return void
-     */
-    public function testDoiHandling()
-    {
-        if (!function_exists('saveResourceInformationAndRights')) {
-            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
-        }
 
-        // Test 1: Updating existing DOI
-        $postDataWithDOI = [
-            "doi" => "10.5880/GFZ.DOI.TEST",
-            "year" => 2023,
-            "dateCreated" => "2023-06-01",
-            "resourcetype" => 1,
-            "language" => 1,
-            "Rights" => 1,
-            "title" => ["DOI Test Dataset"],
-            "titleType" => [1]
-        ];
-
-        // Save first dataset with DOI
-        $first_id = saveResourceInformationAndRights($this->connection, $postDataWithDOI);
-        $this->assertIsInt($first_id, "First save should return a valid resource ID");
-
-        // Update the same DOI with different data
-        $postDataWithDOI["year"] = 2024;
-        $postDataWithDOI["title"] = ["Updated DOI Test Dataset"];
-        $updated_id = saveResourceInformationAndRights($this->connection, $postDataWithDOI);
-        $this->assertEquals($first_id, $updated_id, "Update should return the same resource ID");
-
-        // Test 2: Multiple datasets with null DOI
-        $postDataWithNullDOI = [
-            "doi" => null,
-            "year" => 2023,
-            "dateCreated" => "2023-06-01",
-            "resourcetype" => 1,
-            "language" => 1,
-            "Rights" => 1,
-            "title" => ["Dataset with null DOI"],
-            "titleType" => [1]
-        ];
-
-        // Save first dataset with null DOI
-        $first_null_id = saveResourceInformationAndRights($this->connection, $postDataWithNullDOI);
-        $this->assertIsInt($first_null_id, "First save with null DOI should return valid ID");
-
-        // Save second dataset with null DOI
-        $second_null_id = saveResourceInformationAndRights($this->connection, $postDataWithNullDOI);
-        $this->assertIsInt($second_null_id, "Second save with null DOI should return valid ID");
-        $this->assertNotEquals($first_null_id, $second_null_id, "Null DOI datasets should have different IDs");
-
-        // Test 3: Multiple datasets with empty string DOI
-        $postDataWithEmptyDOI = [
-            "doi" => "",
-            "year" => 2023,
-            "dateCreated" => "2023-06-01",
-            "resourcetype" => 1,
-            "language" => 1,
-            "Rights" => 1,
-            "title" => ["Dataset with empty DOI"],
-            "titleType" => [1]
-        ];
-
-        // Save first dataset with empty DOI
-        $first_empty_id = saveResourceInformationAndRights($this->connection, $postDataWithEmptyDOI);
-        $this->assertIsInt($first_empty_id, "First save with empty DOI should return valid ID");
-
-        // Save second dataset with empty DOI
-        $second_empty_id = saveResourceInformationAndRights($this->connection, $postDataWithEmptyDOI);
-        $this->assertIsInt($second_empty_id, "Second save with empty DOI should return valid ID");
-        $this->assertNotEquals($first_empty_id, $second_empty_id, "Empty DOI datasets should have different IDs");
-
-        // Verify database state
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi = ?");
-        $doi = "10.5880/GFZ.DOI.TEST";
-        $stmt->bind_param("s", $doi);
-        $stmt->execute();
-        $count_with_doi = $stmt->get_result()->fetch_assoc()['count'];
-        $this->assertEquals(1, $count_with_doi, "Should have exactly one dataset with specific DOI");
-
-        // Check title was updated
-        $stmt = $this->connection->prepare("SELECT text FROM Title WHERE Resource_resource_id = ?");
-        $stmt->bind_param("i", $first_id);
-        $stmt->execute();
-        $title = $stmt->get_result()->fetch_assoc()['text'];
-        $this->assertEquals("Updated DOI Test Dataset", $title, "Title should be updated for existing DOI");
-
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi IS NULL");
-        $stmt->execute();
-        $count_null_doi = $stmt->get_result()->fetch_assoc()['count'];
-        $this->assertEquals(2, $count_null_doi, "Should have exactly two datasets with null DOI");
-
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi = ''");
-        $stmt->execute();
-        $count_empty_doi = $stmt->get_result()->fetch_assoc()['count'];
-        $this->assertEquals(2, $count_empty_doi, "Should have exactly two datasets with empty DOI");
-
-        // Verify total count
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource");
-        $stmt->execute();
-        $total_count = $stmt->get_result()->fetch_assoc()['count'];
-        $this->assertEquals(5, $total_count, "Should have five datasets in total");
-    }
 
     /**
      * Tests that a title with text only (without type) is skipped, not saved.
@@ -529,6 +355,7 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
             "resourcetype" => 1,
             "language" => 1,
             "Rights" => 1,
+            "action" => "submit",
             "title" => ["Title Without Type"],
             "titleType" => [""]  // Empty title type
         ];
@@ -593,6 +420,7 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
             "resourcetype" => 1,
             "language" => 1,
             "Rights" => 1,
+            "action" => "submit",
             "title" => [""],  // Empty title text
             "titleType" => ["1"]  // Type without text
         ];
@@ -620,6 +448,7 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
             "resourcetype" => 1,
             "language" => 1,
             "Rights" => 1,
+            "action" => "submit",
             "title" => [""],  // Empty title text
             "titleType" => [""]  // Empty title type
         ];

--- a/tests/SaveResourceInformationAndRightsTest.php
+++ b/tests/SaveResourceInformationAndRightsTest.php
@@ -540,4 +540,129 @@ final class SaveResourceInformationAndRightsTest extends DatabaseTestCase
         $this->assertEquals("Valid Title 2", $titles[1]["text"], "Second valid title should be saved");
         $this->assertEquals(2, $titles[1]["Title_Type_fk"], "Second valid title should have type 2");
     }
+
+    /**
+     * Tests handling of DOIs: updating existing DOIs and allowing multiple empty/null DOIs
+     * 
+     * @return void
+     */
+    public function testDoiHandling()
+    {
+        if (!function_exists('saveResourceInformationAndRights')) {
+            require_once __DIR__ . '/../save/formgroups/save_resourceinformation_and_rights.php';
+        }
+
+        // Test 1: Updating existing DOI
+        $postDataWithDOI = [
+            "doi" => "10.5880/GFZ.DOI.TEST",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["DOI Test Dataset"],
+            "titleType" => [1],
+            "version" => 1.0
+        ];
+
+        // Save first dataset with DOI
+        $first_id = saveResourceInformationAndRights($this->connection, $postDataWithDOI);
+        $this->assertIsInt($first_id, "First save should return a valid resource ID");
+
+        // Update the same DOI with different data
+        $postDataWithDOI["year"] = 2024;
+        $postDataWithDOI["title"] = ["Updated DOI Test Dataset"];
+        $updated_id = saveResourceInformationAndRights($this->connection, $postDataWithDOI);
+
+        // Current:
+        $this->assertNotEquals($first_id, $updated_id, "Update should return the same resource ID");
+/*  Suggested change to close #831:
+        $version_old = $postDataWithDOI["version"];
+        $version_new = $this->connection->query("SELECT version FROM Resource WHERE resource_id = $updated_id")->fetch_assoc()['version'];
+        // Version should be updated to 1.1 (incremented by 0.1) after upload with the same DOI 
+        $this->assertEquals($version_old + 0.1, $version_new, "Version should be incremented on update");
+        // The title and year should be updated
+        $stmt = $this->connection->prepare("SELECT title FROM Title WHERE Resource_resource_id = ?");
+        $stmt->bind_param("i", $updated_id);
+        $stmt->execute();
+        $title = $stmt->get_result()->fetch_assoc()['title'];
+        $this->assertEquals("Updated DOI Test Dataset", $title, "New title for the new version of the DOI");
+        // The year should also be updated to 2024
+        $stmt = $this->connection->prepare("SELECT year FROM Resource WHERE resource_id = ?");
+        $stmt->bind_param("i", $updated_id);
+        $stmt->execute();
+        $year = $stmt->get_result()->fetch_assoc()['year'];
+        $this->assertEquals(2024, $year, "Year should be updated to 2024");
+*/
+
+        // Test 2: Multiple datasets with null DOI
+        $postDataWithNullDOI = [
+            "doi" => null,
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Dataset with null DOI"],
+            "titleType" => [1]
+        ];
+
+        // Save first dataset with null DOI
+        $first_null_id = saveResourceInformationAndRights($this->connection, $postDataWithNullDOI);
+        $this->assertIsInt($first_null_id, "First save with null DOI should return valid ID");
+
+        // Save second dataset with null DOI
+        $second_null_id = saveResourceInformationAndRights($this->connection, $postDataWithNullDOI);
+        $this->assertIsInt($second_null_id, "Second save with null DOI should return valid ID");
+        $this->assertNotEquals($first_null_id, $second_null_id, "Null DOI datasets should have different IDs");
+
+        // Test 3: Multiple datasets with empty string DOI
+        $postDataWithEmptyDOI = [
+            "doi" => "",
+            "year" => 2023,
+            "dateCreated" => "2023-06-01",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Dataset with empty DOI"],
+            "titleType" => [1]
+        ];
+
+        // Save first dataset with empty DOI
+        $first_empty_id = saveResourceInformationAndRights($this->connection, $postDataWithEmptyDOI);
+        $this->assertIsInt($first_empty_id, "First save with empty DOI should return valid ID");
+
+        // Save second dataset with empty DOI
+        $second_empty_id = saveResourceInformationAndRights($this->connection, $postDataWithEmptyDOI);
+        $this->assertIsInt($second_empty_id, "Second save with empty DOI should return valid ID");
+        $this->assertNotEquals($first_empty_id, $second_empty_id, "Empty DOI datasets should have different IDs");
+
+        // Verify database state
+        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi = ?");
+        $doi = "10.5880/GFZ.DOI.TEST";
+        $stmt->bind_param("s", $doi);
+        $stmt->execute();
+        $count_with_doi = $stmt->get_result()->fetch_assoc()['count'];
+        // Suggested to change to 2. two entries with the same DOI but different version should exist after the update
+        $this->assertEquals(2, $count_with_doi, "Should have exactly one dataset with specific DOI");
+
+        // Count datasets with null DOI
+        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi IS NULL");
+        $stmt->execute();
+        $count_null_doi = $stmt->get_result()->fetch_assoc()['count'];
+        $this->assertEquals(2, $count_null_doi, "Should have exactly two datasets with null DOI");
+
+        // Count datasets with empty string DOI
+        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource WHERE doi = ''");
+        $stmt->execute();
+        $count_empty_doi = $stmt->get_result()->fetch_assoc()['count'];
+        $this->assertEquals(2, $count_empty_doi, "Should have exactly two datasets with empty DOI");
+
+        // Verify total count
+        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource");
+        $stmt->execute();
+        $total_count = $stmt->get_result()->fetch_assoc()['count'];
+        // Suggested to change to 6. The original dataset with DOI should be updated, not duplicated, so total count should be 6 instead of 5.
+        $this->assertEquals(6, $total_count, "Should have six datasets in total");
+    }
 }


### PR DESCRIPTION
... but not submitting 
closes #1024 

Also removed the functionality to update an existing resource by DOI. This function introduces risks to the data quality. 

## Changes
included the action into the save tites. Only return false if the action == submit. For save, just return. 


## Notes for Reviewer
### Before:
save without a title is impossible
### After:
saving any metadata without a title should be possible

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
