### PR TITLE
Fix: adjust database numeric formats for ICGEM variables

### DIFF
--- a/install.php
+++ b/install.php
@@ -567,8 +567,8 @@ function createDatabaseStructure($connection): array
     `Error_Handling_Approach` TEXT NULL,
     `Tide_System` VARCHAR(100) NULL,
     `degree` INT NULL,
-    `radius` FLOAT(9,2) NULL,
-    `earth_gravity_constant` FLOAT NULL,
+    `radius` DOUBLE NULL,
+    `earth_gravity_constant` DOUBLE NULL,
     PRIMARY KEY (`GGM_Properties_id`)
 );",
 

--- a/install.php
+++ b/install.php
@@ -643,11 +643,11 @@ function createDatabaseStructure($connection): array
 
         "Ellipsoidal_Parameters" => "CREATE TABLE IF NOT EXISTS `Ellipsoidal_Parameters` (
     `ellipsoidal_parameter_id` INT NOT NULL AUTO_INCREMENT,
-    `semimajor_axis_a` FLOAT (9,2) NOT NULL,
-    `semiminor_axis_b` FLOAT (9,2) NULL,
-    `flattening` FLOAT NULL,
-    `reciprocal_flattening` FLOAT NULL,
-    `excentricity` FLOAT NULL,
+    `semimajor_axis_a` DOUBLE NOT NULL,
+    `semiminor_axis_b` DOUBLE NULL,
+    `flattening` DOUBLE NULL,
+    `reciprocal_flattening` DOUBLE NULL,
+    `excentricity` DOUBLE NULL,
     `description` TEXT NULL,
     PRIMARY KEY (`ellipsoidal_parameter_id`)
         );",


### PR DESCRIPTION
Ellipsoidal parameters are now DOUBLE, because I shouldn't determine the number of digits after point. Better to give the [widest range of opportunities](https://mariadb.com/docs/server/reference/data-types/numeric-data-types/double). 

The earth parameters and radius are also DOUBLE, which unifies data formats and can be reproduced at postres side

## Changes
Changed only DDL statements in install.php

## Notes for Reviewer
Do 
```
docker-compose down 
docker-compose up 

```
set `$showGGMsProperties = true;`

Experiment with input fields if you'd like to


## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
