### PR TITLE
Fix: Second Contributors Affiliation not loaded

### DIFF
--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -663,7 +663,7 @@ function processIndividualContributor(contributor, xmlDoc, resolver, personMap, 
 
   for (let j = 0; j < affiliationNodes.snapshotLength; j++) {
     const affNode = affiliationNodes.snapshotItem(j);
-    const affiliationName = affNode.textContent;
+    const affiliationName = affNode.textContent ? affNode.textContent.trim().replace(/\s+/g, ' ') : '';
     const rorId = affNode.getAttribute("affiliationIdentifier");
 
     if (affiliationName && !affiliationPairs.some(p => p.name === affiliationName)) {
@@ -707,7 +707,12 @@ function updateContributorMap(map, key, newData) {
       existing.roles.push(newData.roles[0]);
     }
     newData.affiliationPairs.forEach((pair) => {
-      if (!existing.affiliationPairs.some(p => p.name === pair.name)) {
+      const existingPair = existing.affiliationPairs.find(p => p.name === pair.name);
+      if (existingPair) {
+        if (!existingPair.rorId && pair.rorId) {
+          existingPair.rorId = pair.rorId;
+        }
+      } else {
         existing.affiliationPairs.push(pair);
       }
     });

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -771,7 +771,6 @@ function populateFormWithContributors(personMap, orgMap) {
   // Process persons
   for (const person of personMap.values()) {
     const personRow = getOrCreatePersonRow(personIndex++);
-    let isClonedRow = personIndex > 1; // First row is original, others are cloned
 
     // Roles
     const roleInput = personRow.find('input[name="cbPersonRoles[]"]')[0];
@@ -792,38 +791,23 @@ function populateFormWithContributors(personMap, orgMap) {
     personRow.find('input[name="cbPersonLastname[]"]').val(person.familyName);
     personRow.find('input[name="cbPersonFirstname[]"]').val(person.givenName);
 
-    // Affiliations - handle both original and cloned field names
-    let affiliationInput;
-    if (isClonedRow) {
-      // Cloned rows use cbPersonAffiliations[] as the name
-      affiliationInput = personRow.find('input[name="cbPersonAffiliations[]"]')[0];
-    } else {
-      // Original row uses cbAffiliation[] as the name
-      affiliationInput = personRow.find('input[name="cbAffiliation[]"]')[0];
-    }
-
+    // Affiliations
+    const affiliationInput = personRow.find('input[name="cbAffiliation[]"]')[0];
     const tagifyAffiliations = getTagifyInstance(affiliationInput);
     if (tagifyAffiliations) {
       tagifyAffiliations.removeAllTags();
       tagifyAffiliations.addTags(person.affiliations.map((aff) => ({ value: aff })));
     } else {
-      console.warn("No Tagify instance found for affiliation input:", affiliationInput, "in row", isClonedRow ? "cloned" : "original");
+      console.warn("No Tagify instance found for affiliation input:", affiliationInput);
     }
 
-    // ROR IDs - handle both original and cloned field names
-    if (isClonedRow) {
-      // Cloned rows use cbPersonRorIds[] as the name
-      personRow.find('input[name="cbPersonRorIds[]"]').val(person.rorIds.join(","));
-    } else {
-      // Original row uses cbpRorIds[] as the name
-      personRow.find('input[name="cbpRorIds[]"]').val(person.rorIds.join(","));
-    }
+    // ROR IDs
+    personRow.find('input[name="cbpRorIds[]"]').val(person.rorIds.join(","));
   }
 
   // Process organizations
   for (const org of orgMap.values()) {
     const orgRow = getOrCreateOrgRow(orgIndex++);
-    let isClonedRow = orgIndex > 1; // First row is original, others are cloned
 
     // Roles
     const roleInput = orgRow.find('input[name="cbOrganisationRoles[]"]')[0];
@@ -838,32 +822,18 @@ function populateFormWithContributors(personMap, orgMap) {
     // Organization name
     orgRow.find('input[name="cbOrganisationName[]"]').val(org.name);
 
-    // Affiliations - handle both original and cloned field names
-    let affiliationInput;
-    if (isClonedRow) {
-      // Cloned rows use cbOrganisationAffiliations[] as the name
-      affiliationInput = orgRow.find('input[name="cbOrganisationAffiliations[]"]')[0];
-    } else {
-      // Original row uses OrganisationAffiliation[] as the name
-      affiliationInput = orgRow.find('input[name="OrganisationAffiliation[]"]')[0];
-    }
-
+    // Affiliations
+    const affiliationInput = orgRow.find('input[name="OrganisationAffiliation[]"]')[0];
     const tagifyAffiliations = getTagifyInstance(affiliationInput);
     if (tagifyAffiliations) {
       tagifyAffiliations.removeAllTags();
       tagifyAffiliations.addTags(org.affiliations.map((aff) => ({ value: aff })));
     } else {
-      console.warn("No Tagify instance found for organization affiliation input:", affiliationInput, "in row", isClonedRow ? "cloned" : "original");
+      console.warn("No Tagify instance found for organization affiliation input:", affiliationInput);
     }
 
-    // ROR IDs - handle both original and cloned field names
-    if (isClonedRow) {
-      // Cloned rows use cbOrganisationRorIds[] as the name
-      orgRow.find('input[name="cbOrganisationRorIds[]"]').val(org.rorIds.join(","));
-    } else {
-      // Original row uses hiddenOrganisationRorId[] as the name
-      orgRow.find('input[name="hiddenOrganisationRorId[]"]').val(org.rorIds.join(","));
-    }
+    // ROR IDs
+    orgRow.find('input[name="hiddenOrganisationRorId[]"]').val(org.rorIds.join(","));
   }
 }
 

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -656,25 +656,21 @@ function processIndividualContributor(contributor, xmlDoc, resolver, personMap, 
   const familyName = getNodeText(contributor, "ns:familyName", xmlDoc, resolver);
   const orcid = getNodeText(contributor, 'ns:nameIdentifier[@schemeURI="https://orcid.org/"]', xmlDoc, resolver);
 
-  // Get affiliations
+  // Get affiliations as aligned pairs of { name, rorId }
   const affiliationNodes = xmlDoc.evaluate("ns:affiliation", contributor, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
 
-  const affiliations = [];
-  const rorIds = [];
+  const affiliationPairs = [];
 
   for (let j = 0; j < affiliationNodes.snapshotLength; j++) {
     const affNode = affiliationNodes.snapshotItem(j);
     const affiliationName = affNode.textContent;
     const rorId = affNode.getAttribute("affiliationIdentifier");
 
-    if (affiliationName && !affiliations.includes(affiliationName)) {
-      affiliations.push(affiliationName);
-      if (rorId) {
-        const cleanRorId = rorId.replace("https://ror.org/", "");
-        if (!rorIds.includes(cleanRorId)) {
-          rorIds.push(cleanRorId);
-        }
-      }
+    if (affiliationName && !affiliationPairs.some(p => p.name === affiliationName)) {
+      affiliationPairs.push({
+        name: affiliationName,
+        rorId: rorId ? rorId.replace("https://ror.org/", "") : ""
+      });
     }
   }
 
@@ -686,16 +682,14 @@ function processIndividualContributor(contributor, xmlDoc, resolver, personMap, 
       givenName,
       familyName,
       orcid,
-      roles: [normalizeRole(contributorType)], // Use normalized role
-      affiliations,
-      rorIds,
+      roles: [normalizeRole(contributorType)],
+      affiliationPairs,
     });
   } else {
     updateContributorMap(orgMap, contributorName, {
       name: contributorName,
-      roles: [normalizeRole(contributorType)], // Use normalized role
-      affiliations,
-      rorIds,
+      roles: [normalizeRole(contributorType)],
+      affiliationPairs,
     });
   }
 }
@@ -712,14 +706,9 @@ function updateContributorMap(map, key, newData) {
     if (!existing.roles.includes(newData.roles[0])) {
       existing.roles.push(newData.roles[0]);
     }
-    newData.affiliations.forEach((aff) => {
-      if (!existing.affiliations.includes(aff)) {
-        existing.affiliations.push(aff);
-      }
-    });
-    newData.rorIds.forEach((rid) => {
-      if (!existing.rorIds.includes(rid)) {
-        existing.rorIds.push(rid);
+    newData.affiliationPairs.forEach((pair) => {
+      if (!existing.affiliationPairs.some(p => p.name === pair.name)) {
+        existing.affiliationPairs.push(pair);
       }
     });
   } else {
@@ -791,18 +780,23 @@ function populateFormWithContributors(personMap, orgMap) {
     personRow.find('input[name="cbPersonLastname[]"]').val(person.familyName);
     personRow.find('input[name="cbPersonFirstname[]"]').val(person.givenName);
 
-    // Affiliations
+    // Affiliations — add tags with both value and id (ROR) for Tagify state consistency
     const affiliationInput = personRow.find('input[name="cbAffiliation[]"]')[0];
     const tagifyAffiliations = getTagifyInstance(affiliationInput);
     if (tagifyAffiliations) {
       tagifyAffiliations.removeAllTags();
-      tagifyAffiliations.addTags(person.affiliations.map((aff) => ({ value: aff })));
+      tagifyAffiliations.addTags(person.affiliationPairs.map((pair) => ({
+        value: pair.name,
+        id: pair.rorId
+      })));
     } else {
       console.warn("No Tagify instance found for affiliation input:", affiliationInput);
     }
 
-    // ROR IDs
-    personRow.find('input[name="cbpRorIds[]"]').val(person.rorIds.join(","));
+    // ROR IDs — aligned with affiliations (empty string for missing ROR IDs)
+    personRow.find('input[name="cbpRorIds[]"]').val(
+      person.affiliationPairs.map((pair) => pair.rorId).join(",")
+    );
   }
 
   // Process organizations
@@ -822,18 +816,23 @@ function populateFormWithContributors(personMap, orgMap) {
     // Organization name
     orgRow.find('input[name="cbOrganisationName[]"]').val(org.name);
 
-    // Affiliations
+    // Affiliations — add tags with both value and id (ROR) for Tagify state consistency
     const affiliationInput = orgRow.find('input[name="OrganisationAffiliation[]"]')[0];
     const tagifyAffiliations = getTagifyInstance(affiliationInput);
     if (tagifyAffiliations) {
       tagifyAffiliations.removeAllTags();
-      tagifyAffiliations.addTags(org.affiliations.map((aff) => ({ value: aff })));
+      tagifyAffiliations.addTags(org.affiliationPairs.map((pair) => ({
+        value: pair.name,
+        id: pair.rorId
+      })));
     } else {
       console.warn("No Tagify instance found for organization affiliation input:", affiliationInput);
     }
 
-    // ROR IDs
-    orgRow.find('input[name="hiddenOrganisationRorId[]"]').val(org.rorIds.join(","));
+    // ROR IDs — aligned with affiliations (empty string for missing ROR IDs)
+    orgRow.find('input[name="hiddenOrganisationRorId[]"]').val(
+      org.affiliationPairs.map((pair) => pair.rorId).join(",")
+    );
   }
 }
 

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -754,7 +754,8 @@ function getTagifyInstance(inputElement) {
 }
 
 /**
- * Populate the form with processed contributor data, handling both original and cloned field names
+ * Populate the form with processed contributor data using canonical field names
+ * (cbAffiliation[], cbpRorIds[], OrganisationAffiliation[], hiddenOrganisationRorId[]).
  * @param {Map} personMap - Map containing person contributors
  * @param {Map} orgMap - Map containing organization contributors
  */

--- a/tests/js/mappingXmlToInputFields.module.test.js
+++ b/tests/js/mappingXmlToInputFields.module.test.js
@@ -316,6 +316,42 @@ describe('mappingXmlToInputFields module coverage', () => {
             const entry = map.get('key1');
             expect(entry.affiliationPairs.length).toBe(1);
         });
+
+        test('upgrades empty rorId when incoming pair has a value', () => {
+            const map = new Map();
+            map.set('key1', { 
+                name: 'Test', 
+                roles: ['Role1'],
+                affiliationPairs: [{ name: 'Org1', rorId: '' }]
+            });
+            
+            mappingModule.updateContributorMap(map, 'key1', { 
+                name: 'Test', 
+                roles: ['Role1'],
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror123' }]
+            });
+            
+            const entry = map.get('key1');
+            expect(entry.affiliationPairs).toEqual([{ name: 'Org1', rorId: 'ror123' }]);
+        });
+
+        test('does not overwrite existing rorId with incoming value', () => {
+            const map = new Map();
+            map.set('key1', { 
+                name: 'Test', 
+                roles: ['Role1'],
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror_original' }]
+            });
+            
+            mappingModule.updateContributorMap(map, 'key1', { 
+                name: 'Test', 
+                roles: ['Role1'],
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror_different' }]
+            });
+            
+            const entry = map.get('key1');
+            expect(entry.affiliationPairs).toEqual([{ name: 'Org1', rorId: 'ror_original' }]);
+        });
     });
 
     describe('parseTemporalData', () => {

--- a/tests/js/mappingXmlToInputFields.module.test.js
+++ b/tests/js/mappingXmlToInputFields.module.test.js
@@ -232,8 +232,7 @@ describe('mappingXmlToInputFields module coverage', () => {
             const newData = { 
                 name: 'Test', 
                 roles: ['DataCurator'],
-                affiliations: ['Org1'],
-                rorIds: ['ror123']
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror123' }]
             };
             
             mappingModule.updateContributorMap(map, 'key1', newData);
@@ -247,15 +246,13 @@ describe('mappingXmlToInputFields module coverage', () => {
             map.set('key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: [],
-                rorIds: []
+                affiliationPairs: []
             });
             
             mappingModule.updateContributorMap(map, 'key1', { 
                 name: 'Test', 
                 roles: ['Role2'],
-                affiliations: [],
-                rorIds: []
+                affiliationPairs: []
             });
             
             const entry = map.get('key1');
@@ -268,61 +265,56 @@ describe('mappingXmlToInputFields module coverage', () => {
             map.set('key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: [],
-                rorIds: []
+                affiliationPairs: []
             });
             
             mappingModule.updateContributorMap(map, 'key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: [],
-                rorIds: []
+                affiliationPairs: []
             });
             
             const entry = map.get('key1');
             expect(entry.roles.filter(r => r === 'Role1').length).toBe(1);
         });
 
-        test('merges affiliations', () => {
+        test('merges affiliationPairs', () => {
             const map = new Map();
             map.set('key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: ['Org1'],
-                rorIds: []
+                affiliationPairs: [{ name: 'Org1', rorId: '' }]
             });
             
             mappingModule.updateContributorMap(map, 'key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: ['Org2'],
-                rorIds: []
+                affiliationPairs: [{ name: 'Org2', rorId: 'ror456' }]
             });
             
             const entry = map.get('key1');
-            expect(entry.affiliations).toContain('Org1');
-            expect(entry.affiliations).toContain('Org2');
+            expect(entry.affiliationPairs).toEqual([
+                { name: 'Org1', rorId: '' },
+                { name: 'Org2', rorId: 'ror456' }
+            ]);
         });
 
-        test('merges rorIds', () => {
+        test('does not duplicate existing affiliationPairs', () => {
             const map = new Map();
             map.set('key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: [],
-                rorIds: ['ror1']
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror1' }]
             });
             
             mappingModule.updateContributorMap(map, 'key1', { 
                 name: 'Test', 
                 roles: ['Role1'],
-                affiliations: [],
-                rorIds: ['ror2']
+                affiliationPairs: [{ name: 'Org1', rorId: 'ror1' }]
             });
             
             const entry = map.get('key1');
-            expect(entry.rorIds).toContain('ror1');
-            expect(entry.rorIds).toContain('ror2');
+            expect(entry.affiliationPairs.length).toBe(1);
         });
     });
 

--- a/tests/playwright/flows/contributor-affiliation-roundtrip.spec.ts
+++ b/tests/playwright/flows/contributor-affiliation-roundtrip.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+import { navigateToHome } from '../utils';
+
+/**
+ * XML with two contributor persons, each having an affiliation and ROR ID
+ * but no ORCID. This reproduces the scenario from issue #1047.
+ */
+const XML_TWO_CONTRIBUTOR_PERSONS = `<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://datacite.org/schema/kernel-4"
+          xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.7/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/CONTRIB-TEST</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Doe, Jane</creatorName>
+      <givenName>Jane</givenName>
+      <familyName>Doe</familyName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Contributor Affiliation Roundtrip Test</title>
+  </titles>
+  <publisher xml:lang="en">GFZ Data Services</publisher>
+  <publicationYear>2025</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
+  <contributors>
+    <contributor contributorType="DataCurator">
+      <contributorName nameType="Personal">Schmidt, Hans</contributorName>
+      <givenName>Hans</givenName>
+      <familyName>Schmidt</familyName>
+      <affiliation affiliationIdentifier="https://ror.org/04z8jg394" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">Helmholtz-Zentrum Potsdam Deutsches GeoForschungsZentrum GFZ</affiliation>
+    </contributor>
+    <contributor contributorType="Researcher">
+      <contributorName nameType="Personal">Mueller, Erika</contributorName>
+      <givenName>Erika</givenName>
+      <familyName>Mueller</familyName>
+      <affiliation affiliationIdentifier="https://ror.org/01bj3aw27" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">Technical University of Berlin</affiliation>
+    </contributor>
+  </contributors>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">Test abstract.</description>
+  </descriptions>
+</resource>`;
+
+/**
+ * XML with two contributor organisations, each having an affiliation and ROR ID.
+ */
+const XML_TWO_CONTRIBUTOR_ORGS = `<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://datacite.org/schema/kernel-4"
+          xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.7/metadata.xsd">
+  <identifier identifierType="DOI">10.82433/CONTRIB-ORG-TEST</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Doe, Jane</creatorName>
+      <givenName>Jane</givenName>
+      <familyName>Doe</familyName>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">Contributor Org Affiliation Roundtrip Test</title>
+  </titles>
+  <publisher xml:lang="en">GFZ Data Services</publisher>
+  <publicationYear>2025</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
+  <contributors>
+    <contributor contributorType="HostingInstitution">
+      <contributorName nameType="Organizational">GFZ German Research Centre for Geosciences</contributorName>
+      <affiliation affiliationIdentifier="https://ror.org/04z8jg394" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">Helmholtz-Zentrum Potsdam Deutsches GeoForschungsZentrum GFZ</affiliation>
+    </contributor>
+    <contributor contributorType="Distributor">
+      <contributorName nameType="Organizational">Technical University of Berlin</contributorName>
+      <affiliation affiliationIdentifier="https://ror.org/01bj3aw27" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">TU Berlin</affiliation>
+    </contributor>
+  </contributors>
+  <descriptions>
+    <description xml:lang="en" descriptionType="Abstract">Test abstract for orgs.</description>
+  </descriptions>
+</resource>`;
+
+async function uploadXml(page: import('@playwright/test').Page, xmlContent: string, filename: string) {
+  await page.locator('#button-form-load').click();
+  const modal = page.locator('div#modal-uploadxml');
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+
+  await page.setInputFiles('#input-uploadxml-file', {
+    name: filename,
+    mimeType: 'text/xml',
+    buffer: Buffer.from(xmlContent, 'utf-8'),
+  });
+}
+
+test.describe('Contributor Affiliation Roundtrip (Issue #1047)', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToHome(page);
+    await expect(page.locator('#input-resourceinformation-doi')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('second contributor person affiliation is loaded from XML', async ({ page }) => {
+    // The contributor persons card contains [contributor-person-row] attribute
+    const personContainer = page.locator('[contributor-person-row]').first().locator('..');
+    test.skip(!(await personContainer.isVisible()), 'Contributor Persons form group is not enabled');
+
+    await uploadXml(page, XML_TWO_CONTRIBUTOR_PERSONS, 'two-contributors.xml');
+
+    // Wait for XML to be processed by checking title field
+    await expect(page.locator('#input-resourceinformation-title')).toHaveValue(
+      'Contributor Affiliation Roundtrip Test',
+      { timeout: 20_000 },
+    );
+
+    // Verify first contributor person — select rows by the attribute selector
+    const personRows = page.locator('[contributor-person-row]');
+    const firstPerson = personRows.nth(0);
+    await expect(firstPerson.locator('input[name="cbPersonLastname[]"]')).toHaveValue('Schmidt');
+    await expect(firstPerson.locator('input[name="cbPersonFirstname[]"]')).toHaveValue('Hans');
+
+    // Check first contributor affiliation via Tagify tag on the affiliation input
+    const firstAffTags = firstPerson.locator('input[name="cbAffiliation[]"]').locator('..').locator('tags.tagify tag');
+    await expect(firstAffTags.first()).toBeVisible({ timeout: 10_000 });
+    await expect(firstAffTags.first()).toContainText('Helmholtz-Zentrum Potsdam');
+
+    // Verify second contributor person
+    const secondPerson = personRows.nth(1);
+    await expect(secondPerson.locator('input[name="cbPersonLastname[]"]')).toHaveValue('Mueller');
+    await expect(secondPerson.locator('input[name="cbPersonFirstname[]"]')).toHaveValue('Erika');
+
+    // THIS IS THE BUG: second contributor's affiliation must also be loaded
+    const secondAffTags = secondPerson.locator('input[name="cbAffiliation[]"]').locator('..').locator('tags.tagify tag');
+    await expect(secondAffTags.first()).toBeVisible({ timeout: 10_000 });
+    await expect(secondAffTags.first()).toContainText('Technical University of Berlin');
+
+    // Verify ROR IDs are set for both contributors
+    await expect(firstPerson.locator('input[name="cbpRorIds[]"]')).toHaveValue('04z8jg394');
+    await expect(secondPerson.locator('input[name="cbpRorIds[]"]')).toHaveValue('01bj3aw27');
+  });
+
+  test('second contributor organisation affiliation is loaded from XML', async ({ page }) => {
+    // Skip if contributor institutions form group is not visible
+    const contributorOrgCard = page.locator('#group-contributororganisation');
+    test.skip(!(await contributorOrgCard.isVisible()), 'Contributor Institutions form group is not enabled');
+
+    await uploadXml(page, XML_TWO_CONTRIBUTOR_ORGS, 'two-contributor-orgs.xml');
+
+    // Wait for XML to be processed
+    await expect(page.locator('#input-resourceinformation-title')).toHaveValue(
+      'Contributor Org Affiliation Roundtrip Test',
+      { timeout: 20_000 },
+    );
+
+    // Verify first organisation
+    const orgRows = page.locator('#group-contributororganisation [contributors-row]');
+    const firstOrg = orgRows.nth(0);
+    await expect(firstOrg.locator('input[name="cbOrganisationName[]"]')).toHaveValue(
+      'GFZ German Research Centre for Geosciences',
+    );
+
+    // Check first org affiliation via Tagify tag — target specifically the affiliation input's tags
+    const firstAffTags = firstOrg.locator('input[name="OrganisationAffiliation[]"]').locator('..').locator('tags.tagify tag');
+    await expect(firstAffTags.first()).toBeVisible({ timeout: 10_000 });
+    await expect(firstAffTags.first()).toContainText('Helmholtz-Zentrum Potsdam');
+
+    // Verify second organisation
+    const secondOrg = orgRows.nth(1);
+    await expect(secondOrg.locator('input[name="cbOrganisationName[]"]')).toHaveValue(
+      'Technical University of Berlin',
+    );
+
+    // THIS IS THE BUG: second org's affiliation must also be loaded
+    const secondAffTags = secondOrg.locator('input[name="OrganisationAffiliation[]"]').locator('..').locator('tags.tagify tag');
+    await expect(secondAffTags.first()).toBeVisible({ timeout: 10_000 });
+    await expect(secondAffTags.first()).toContainText('TU Berlin');
+
+    // Verify ROR IDs
+    await expect(firstOrg.locator('input[name="hiddenOrganisationRorId[]"]')).toHaveValue('04z8jg394');
+    await expect(secondOrg.locator('input[name="hiddenOrganisationRorId[]"]')).toHaveValue('01bj3aw27');
+  });
+});


### PR DESCRIPTION
This pull request refactors how contributor affiliations and ROR IDs are handled throughout the codebase, ensuring that affiliations and their corresponding ROR IDs are always kept as aligned pairs. This change fixes issues where contributor affiliations (especially for the second contributor or organization) were not reliably loaded from XML, and improves data consistency for downstream form population and Tagify widget integration. The update also includes expanded unit tests and a new Playwright flow test to verify roundtrip XML loading for contributor affiliations.

The most important changes are:

**Refactor and Data Structure Alignment:**
* Replaces separate `affiliations` and `rorIds` arrays with a single `affiliationPairs` array of objects `{ name, rorId }` throughout contributor processing, ensuring that each affiliation is always paired with its ROR ID. [[1]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L659-R673) [[2]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L689-R692)
* Updates the `updateContributorMap` function to merge `affiliationPairs` correctly, upgrading empty ROR IDs when new information is available, and preventing duplicate pairs.

**Form Population and UI Integration:**
* Refactors form population logic to use `affiliationPairs` for both persons and organizations, ensuring Tagify tags and ROR ID fields are always consistent and correctly populated for each contributor row. [[1]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L795-L826) [[2]](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85L841-R840)

**Testing and Validation:**
* Updates and expands unit tests to cover new `affiliationPairs` logic, including merging, upgrades, and deduplication. [[1]](diffhunk://#diff-f5d8944287383a5d39b4bcf9c4efd4ddf7fb72bcb54f63be01effae24a90f0c2L235-R235) [[2]](diffhunk://#diff-f5d8944287383a5d39b4bcf9c4efd4ddf7fb72bcb54f63be01effae24a90f0c2L250-R255) [[3]](diffhunk://#diff-f5d8944287383a5d39b4bcf9c4efd4ddf7fb72bcb54f63be01effae24a90f0c2L271-R353)
* Adds a new Playwright flow test to verify that multiple contributor affiliations and ROR IDs are correctly loaded from XML and displayed in the UI, preventing regressions for the fixed bug (issue #1047).

## Notes for Reviewer
None.

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None.