### PR TITLE
Fix: Streamline frontend validation for Title and Author names input

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -16,6 +16,7 @@
                     <li><strong>Fixes:</strong>
                         <ul>
                             <li>Fixed inconsistent placeholder language when auto-detecting browser language</li>
+                            <li>Fixed inconsistent validation of title</li>
                         </ul>
                     </li>
                 </ul>

--- a/js/checkMandatoryFields.js
+++ b/js/checkMandatoryFields.js
@@ -681,12 +681,6 @@ function validateAllMandatoryFields() {
     // Formgroup Autor Institution
     validateAuthorInstitutionRequirements();
 
-    // Formgroup Resource Information - Title
-    validateTitleField();
-
-    // Formgroup Authors - First/Last Name
-    validateAuthorNameFields();
-
     // for the entire form
     removeGreenCheckmarks();
 

--- a/js/checkMandatoryFields.js
+++ b/js/checkMandatoryFields.js
@@ -438,6 +438,108 @@ if (errorHandlingApproach) {
         errorHandlingApproach.addEventListener(evt, validateErrorHandlingApproachField)
     );
 }
+
+// Select the title input element
+const titleInput = document.getElementById('input-resourceinformation-title');
+// Add event listeners for both input (typing) and blur (leaving the field) if element exists
+if (titleInput) {
+    ['input', 'blur'].forEach(evt =>
+        titleInput.addEventListener(evt, validateTitleField)
+    );
+}
+
+/**
+ * Validates the resource title input field.
+ * - Marks the field as valid if it contains non-whitespace text.
+ * - Marks the field as invalid if it is empty or contains only whitespace.
+ * - Uses setCustomValidity() so that HTML5 checkValidity() also rejects whitespace-only input.
+ */
+function validateTitleField() {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    if (!titleInput) return true;
+    const value = titleInput.value.trim();
+    const container = titleInput.closest('.input-group') || titleInput.parentElement;
+
+    titleInput.classList.remove('is-valid', 'is-invalid');
+
+    let oldFeedback = container.querySelector('.invalid-feedback[data-translate="resourceInfo.resourceTitleInvalid"]');
+    if (oldFeedback) oldFeedback.remove();
+
+    if (value.length === 0) {
+        titleInput.classList.add('is-invalid');
+        const message = (typeof translations !== 'undefined' && translations.resourceInfo)
+            ? translations.resourceInfo.resourceTitleInvalid
+            : 'Please provide a title.';
+        const feedbackElem = document.createElement('div');
+        feedbackElem.className = 'invalid-feedback';
+        feedbackElem.setAttribute('data-translate', 'resourceInfo.resourceTitleInvalid');
+        feedbackElem.innerText = message;
+        container.appendChild(feedbackElem);
+        titleInput.setCustomValidity(message);
+        return false;
+    } else {
+        titleInput.classList.add('is-valid');
+        titleInput.setCustomValidity("");
+        return true;
+    }
+}
+
+// Select the author name input elements
+const authorLastname = document.getElementById('input-author-lastname');
+const authorFirstname = document.getElementById('input-author-firstname');
+[authorLastname, authorFirstname].forEach(el => {
+    if (el) {
+        ['input', 'blur'].forEach(evt =>
+            el.addEventListener(evt, validateAuthorNameFields)
+        );
+    }
+});
+
+/**
+ * Validates the first author's last name and first name input fields.
+ * - Marks each field as valid if it contains non-whitespace text.
+ * - Marks each field as invalid if it is empty or contains only whitespace.
+ * - Uses setCustomValidity() so that HTML5 checkValidity() also rejects whitespace-only input.
+ */
+function validateAuthorNameFields() {
+    let isValid = true;
+    const fields = [
+        { id: 'input-author-lastname', translationKey: 'general.lastNameInvalid' },
+        { id: 'input-author-firstname', translationKey: 'general.firstNameInvalid' }
+    ];
+
+    fields.forEach(({ id, translationKey }) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        const value = input.value.trim();
+        const container = input.closest('.input-group') || input.parentElement;
+
+        input.classList.remove('is-valid', 'is-invalid');
+
+        let oldFeedback = container.querySelector(`.invalid-feedback[data-translate="${translationKey}"]`);
+        if (oldFeedback) oldFeedback.remove();
+
+        const [section, key] = translationKey.split('.');
+        if (value.length === 0) {
+            input.classList.add('is-invalid');
+            const message = (typeof translations !== 'undefined' && translations[section])
+                ? translations[section][key]
+                : translationKey;
+            const feedbackElem = document.createElement('div');
+            feedbackElem.className = 'invalid-feedback';
+            feedbackElem.setAttribute('data-translate', translationKey);
+            feedbackElem.innerText = message;
+            container.appendChild(feedbackElem);
+            input.setCustomValidity(message);
+            isValid = false;
+        } else {
+            input.classList.add('is-valid');
+            input.setCustomValidity("");
+        }
+    });
+
+    return isValid;
+}
 /**
  * Validates the error handling approach textarea field.
  * - Returns success automatically if the field is not required or not present.
@@ -579,6 +681,12 @@ function validateAllMandatoryFields() {
     // Formgroup Autor Institution
     validateAuthorInstitutionRequirements();
 
+    // Formgroup Resource Information - Title
+    validateTitleField();
+
+    // Formgroup Authors - First/Last Name
+    validateAuthorNameFields();
+
     // for the entire form
     removeGreenCheckmarks();
 
@@ -683,6 +791,9 @@ $(document).on('blur',
     'input[name="tscTimeEnd[]"],' +
     'input[name="rIdentifier[]"],' +
     'input[name="awardURI[]"], ' +
+    'input[name="title[]"], ' +
+    'input[name="familynames[]"], ' +
+    'input[name="givennames[]"], ' +
     'textarea#input-abstract' , +
     'textarea#input-error-handling-approach',
 
@@ -718,6 +829,8 @@ $(document).on('change',
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         validateSpatialTemporalCoverageRequirements,
-        validateAllMandatoryFields
+        validateAllMandatoryFields,
+        validateTitleField,
+        validateAuthorNameFields
     };
 }

--- a/js/submitHandler.js
+++ b/js/submitHandler.js
@@ -298,6 +298,8 @@ class SubmitHandler {
             this.autosaveService.flushPending();
         }
         validateEmbargoDate();
+        validateTitleField();
+        validateAuthorNameFields();
         const temporalCoverageValid = validateAllTemporalCoverageRows();
         if (!this.$form[0].checkValidity() || !validateContactPerson() || !temporalCoverageValid) {
             this.$form.addClass('was-validated');

--- a/tests/js/submitHandler.test.js
+++ b/tests/js/submitHandler.test.js
@@ -87,6 +87,10 @@ describe('submitHandler.js', () => {
         // Mock applyTranslations function
     global.applyTranslations = jest.fn();
 
+    // Mock whitespace-only validators from checkMandatoryFields.js
+    global.validateTitleField = jest.fn().mockReturnValue(true);
+    global.validateAuthorNameFields = jest.fn().mockReturnValue(true);
+
     // Mock scrollIntoView
     Element.prototype.scrollIntoView = jest.fn();
 
@@ -96,6 +100,8 @@ describe('submitHandler.js', () => {
   afterEach(() => {
     jest.useRealTimers();
     console.error.mockRestore();
+    delete global.validateTitleField;
+    delete global.validateAuthorNameFields;
   });
 
   test('validateEmbargoDate marks invalid when embargo before creation', () => {

--- a/tests/js/whitespaceValidation.test.js
+++ b/tests/js/whitespaceValidation.test.js
@@ -1,0 +1,627 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Tests for validateTitleField and validateAuthorNameFields.
+ * Ensures that whitespace-only input is rejected with proper UI feedback.
+ * Addresses GitHub Issue #763.
+ */
+describe('validateTitleField', () => {
+  let $;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="form-mde">
+        <div id="group-resourceinformation">
+          <div class="row">
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-resourceinformation-title" name="title[]" required />
+                  <label for="input-resourceinformation-title">Title</label>
+                  <div class="invalid-feedback" data-translate="resourceInfo.resourceTitleInvalid"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="group-author">
+          <div class="row">
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-lastname" name="familynames[]" required />
+                  <label for="input-author-lastname">Last Name</label>
+                  <div class="invalid-feedback" data-translate="general.lastNameInvalid"></div>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-firstname" name="givennames[]" required />
+                  <label for="input-author-firstname">First Name</label>
+                  <div class="invalid-feedback" data-translate="general.firstNameInvalid"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    `;
+
+    // Set up jQuery
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
+
+    // Set up translations
+    window.translations = {
+      resourceInfo: {
+        resourceTitleInvalid: 'Please provide a descriptive title (that does not repeat the paper title, but describes the data).'
+      },
+      general: {
+        lastNameInvalid: 'Please provide a lastname. Letters only. No digits or special characters (e.g. $, %, _).',
+        firstNameInvalid: 'Please provide a firstname. Letters only. No digits or special characters (e.g. $, %, _).'
+      },
+      descriptions: {
+        abstractInvalid: 'Please enter a valid abstract text.'
+      }
+    };
+    // Make translations accessible as a global (the script uses `translations` without `window.`)
+    global.translations = window.translations;
+
+    // Load the script
+    const scriptPath = path.resolve(__dirname, '../../js/checkMandatoryFields.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.eval(scriptContent);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.$;
+    delete global.jQuery;
+    delete global.translations;
+    delete window.$;
+    delete window.jQuery;
+    delete window.translations;
+    delete window.applyTagifyAccessibilityAttributes;
+  });
+
+  // --- validateTitleField tests ---
+
+  test('rejects empty title (empty string)', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '';
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(false);
+    expect(titleInput.classList.contains('is-invalid')).toBe(true);
+    expect(titleInput.classList.contains('is-valid')).toBe(false);
+    expect(titleInput.validity.valid).toBe(false);
+  });
+
+  test('rejects whitespace-only title (spaces)', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '     ';
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(false);
+    expect(titleInput.classList.contains('is-invalid')).toBe(true);
+    expect(titleInput.classList.contains('is-valid')).toBe(false);
+    expect(titleInput.validity.valid).toBe(false);
+  });
+
+  test('rejects whitespace-only title (tabs and newlines)', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '\t\n  \t';
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(false);
+    expect(titleInput.classList.contains('is-invalid')).toBe(true);
+  });
+
+  test('accepts valid title text', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = 'My Research Dataset';
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(true);
+    expect(titleInput.classList.contains('is-valid')).toBe(true);
+    expect(titleInput.classList.contains('is-invalid')).toBe(false);
+    expect(titleInput.validity.valid).toBe(true);
+  });
+
+  test('accepts title with leading/trailing spaces (trimmed content is non-empty)', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '  My Dataset  ';
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(true);
+    expect(titleInput.classList.contains('is-valid')).toBe(true);
+  });
+
+  test('creates feedback element with correct data-translate attribute', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '   ';
+
+    window.validateTitleField();
+
+    const container = titleInput.closest('.input-group') || titleInput.parentElement;
+    const feedback = container.querySelector('.invalid-feedback[data-translate="resourceInfo.resourceTitleInvalid"]');
+    expect(feedback).not.toBeNull();
+    expect(feedback.innerText).toBe(window.translations.resourceInfo.resourceTitleInvalid);
+  });
+
+  test('removes old feedback element before adding new one', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '   ';
+
+    // Validate twice to ensure no duplicate feedback elements
+    window.validateTitleField();
+    window.validateTitleField();
+
+    const container = titleInput.closest('.input-group') || titleInput.parentElement;
+    const feedbacks = container.querySelectorAll('.invalid-feedback[data-translate="resourceInfo.resourceTitleInvalid"]');
+    expect(feedbacks.length).toBe(1);
+  });
+
+  test('clears invalid state when valid value is entered after invalid', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+
+    // First: invalid
+    titleInput.value = '   ';
+    window.validateTitleField();
+    expect(titleInput.classList.contains('is-invalid')).toBe(true);
+
+    // Then: valid
+    titleInput.value = 'Valid Title';
+    window.validateTitleField();
+    expect(titleInput.classList.contains('is-valid')).toBe(true);
+    expect(titleInput.classList.contains('is-invalid')).toBe(false);
+    expect(titleInput.validity.valid).toBe(true);
+  });
+
+  test('sets customValidity so checkValidity() returns false for whitespace-only', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = '   ';
+
+    window.validateTitleField();
+
+    // HTML5 checkValidity should now fail
+    expect(titleInput.checkValidity()).toBe(false);
+  });
+
+  test('clears customValidity for valid values so checkValidity() returns true', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    titleInput.value = 'Valid Dataset Title';
+
+    window.validateTitleField();
+
+    expect(titleInput.checkValidity()).toBe(true);
+  });
+
+  test('returns true when title element does not exist', () => {
+    document.getElementById('input-resourceinformation-title').remove();
+
+    const result = window.validateTitleField();
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('validateAuthorNameFields', () => {
+  let $;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="form-mde">
+        <div id="group-author">
+          <div class="row">
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-lastname" name="familynames[]" required />
+                  <label for="input-author-lastname">Last Name</label>
+                  <div class="invalid-feedback" data-translate="general.lastNameInvalid"></div>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-firstname" name="givennames[]" required />
+                  <label for="input-author-firstname">First Name</label>
+                  <div class="invalid-feedback" data-translate="general.firstNameInvalid"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    `;
+
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
+
+    window.translations = {
+      resourceInfo: {
+        resourceTitleInvalid: 'Please provide a descriptive title.'
+      },
+      general: {
+        lastNameInvalid: 'Please provide a lastname. Letters only. No digits or special characters (e.g. $, %, _).',
+        firstNameInvalid: 'Please provide a firstname. Letters only. No digits or special characters (e.g. $, %, _).'
+      },
+      descriptions: {
+        abstractInvalid: 'Please enter a valid abstract text.'
+      }
+    };
+    global.translations = window.translations;
+
+    const scriptPath = path.resolve(__dirname, '../../js/checkMandatoryFields.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.eval(scriptContent);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.$;
+    delete global.jQuery;
+    delete global.translations;
+    delete window.$;
+    delete window.jQuery;
+    delete window.translations;
+    delete window.applyTagifyAccessibilityAttributes;
+  });
+
+  // --- Last name validation ---
+
+  test('rejects whitespace-only last name', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '   ';
+    firstname.value = 'John';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(false);
+    expect(lastname.classList.contains('is-invalid')).toBe(true);
+    expect(firstname.classList.contains('is-valid')).toBe(true);
+  });
+
+  test('rejects empty last name', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '';
+    firstname.value = 'John';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(false);
+    expect(lastname.classList.contains('is-invalid')).toBe(true);
+  });
+
+  // --- First name validation ---
+
+  test('rejects whitespace-only first name', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = 'Doe';
+    firstname.value = '   ';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(false);
+    expect(firstname.classList.contains('is-invalid')).toBe(true);
+    expect(lastname.classList.contains('is-valid')).toBe(true);
+  });
+
+  test('rejects empty first name', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = 'Doe';
+    firstname.value = '';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(false);
+    expect(firstname.classList.contains('is-invalid')).toBe(true);
+  });
+
+  // --- Both fields invalid ---
+
+  test('rejects both fields when both are whitespace-only', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(false);
+    expect(lastname.classList.contains('is-invalid')).toBe(true);
+    expect(firstname.classList.contains('is-invalid')).toBe(true);
+  });
+
+  // --- Both fields valid ---
+
+  test('accepts valid author names', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = 'Doe';
+    firstname.value = 'John';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(true);
+    expect(lastname.classList.contains('is-valid')).toBe(true);
+    expect(firstname.classList.contains('is-valid')).toBe(true);
+    expect(lastname.classList.contains('is-invalid')).toBe(false);
+    expect(firstname.classList.contains('is-invalid')).toBe(false);
+  });
+
+  test('accepts compound names with spaces (e.g. "van der Berg")', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = 'van der Berg';
+    firstname.value = 'Jan';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(true);
+    expect(lastname.classList.contains('is-valid')).toBe(true);
+  });
+
+  test('accepts names with leading/trailing spaces (trimmed content non-empty)', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '  Doe  ';
+    firstname.value = '  John  ';
+
+    const result = window.validateAuthorNameFields();
+
+    expect(result).toBe(true);
+    expect(lastname.classList.contains('is-valid')).toBe(true);
+    expect(firstname.classList.contains('is-valid')).toBe(true);
+  });
+
+  // --- Feedback element handling ---
+
+  test('creates feedback elements with correct data-translate attributes', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    window.validateAuthorNameFields();
+
+    const lastnameContainer = lastname.closest('.input-group') || lastname.parentElement;
+    const firstnameContainer = firstname.closest('.input-group') || firstname.parentElement;
+    const lastnameFeedback = lastnameContainer.querySelector('.invalid-feedback[data-translate="general.lastNameInvalid"]');
+    const firstnameFeedback = firstnameContainer.querySelector('.invalid-feedback[data-translate="general.firstNameInvalid"]');
+
+    expect(lastnameFeedback).not.toBeNull();
+    expect(lastnameFeedback.innerText).toBe(window.translations.general.lastNameInvalid);
+    expect(firstnameFeedback).not.toBeNull();
+    expect(firstnameFeedback.innerText).toBe(window.translations.general.firstNameInvalid);
+  });
+
+  test('does not duplicate feedback elements on multiple validations', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    lastname.value = '   ';
+    const firstname = document.getElementById('input-author-firstname');
+    firstname.value = 'John';
+
+    window.validateAuthorNameFields();
+    window.validateAuthorNameFields();
+    window.validateAuthorNameFields();
+
+    const container = lastname.closest('.input-group') || lastname.parentElement;
+    const feedbacks = container.querySelectorAll('.invalid-feedback[data-translate="general.lastNameInvalid"]');
+    expect(feedbacks.length).toBe(1);
+  });
+
+  // --- State transitions ---
+
+  test('clears invalid state when valid value is entered after whitespace-only', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    // First: both invalid
+    lastname.value = '   ';
+    firstname.value = '   ';
+    window.validateAuthorNameFields();
+    expect(lastname.classList.contains('is-invalid')).toBe(true);
+    expect(firstname.classList.contains('is-invalid')).toBe(true);
+
+    // Then: both valid
+    lastname.value = 'Doe';
+    firstname.value = 'Jane';
+    window.validateAuthorNameFields();
+    expect(lastname.classList.contains('is-valid')).toBe(true);
+    expect(firstname.classList.contains('is-valid')).toBe(true);
+    expect(lastname.classList.contains('is-invalid')).toBe(false);
+    expect(firstname.classList.contains('is-invalid')).toBe(false);
+  });
+
+  // --- setCustomValidity integration ---
+
+  test('sets customValidity so checkValidity() returns false for whitespace-only names', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    window.validateAuthorNameFields();
+
+    expect(lastname.checkValidity()).toBe(false);
+    expect(firstname.checkValidity()).toBe(false);
+  });
+
+  test('clears customValidity for valid names so checkValidity() returns true', () => {
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+    lastname.value = 'Doe';
+    firstname.value = 'John';
+
+    window.validateAuthorNameFields();
+
+    expect(lastname.checkValidity()).toBe(true);
+    expect(firstname.checkValidity()).toBe(true);
+  });
+});
+
+describe('validateTitleField and validateAuthorNameFields integration', () => {
+  let $;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="form-mde">
+        <div id="group-resourceinformation">
+          <div class="row">
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-resourceinformation-title" name="title[]" required />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="group-author">
+          <div class="row">
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-lastname" name="familynames[]" required />
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="input-group has-validation">
+                <div class="form-floating">
+                  <input type="text" class="form-control js-required-on-submit"
+                    id="input-author-firstname" name="givennames[]" required />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    `;
+
+    $ = require('jquery');
+    global.$ = global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
+
+    window.translations = {
+      resourceInfo: {
+        resourceTitleInvalid: 'Please provide a descriptive title.'
+      },
+      general: {
+        lastNameInvalid: 'Please provide a lastname.',
+        firstNameInvalid: 'Please provide a firstname.'
+      },
+      descriptions: {
+        abstractInvalid: 'Please enter a valid abstract text.'
+      }
+    };
+    global.translations = window.translations;
+
+    const scriptPath = path.resolve(__dirname, '../../js/checkMandatoryFields.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.eval(scriptContent);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.$;
+    delete global.jQuery;
+    delete global.translations;
+    delete window.$;
+    delete window.jQuery;
+    delete window.translations;
+    delete window.applyTagifyAccessibilityAttributes;
+  });
+
+  test('form checkValidity() fails when title is whitespace-only', () => {
+    const form = document.getElementById('form-mde');
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    titleInput.value = '   ';
+    lastname.value = 'Doe';
+    firstname.value = 'John';
+
+    window.validateTitleField();
+    window.validateAuthorNameFields();
+
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  test('form checkValidity() fails when author names are whitespace-only', () => {
+    const form = document.getElementById('form-mde');
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    titleInput.value = 'Valid Title';
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    window.validateTitleField();
+    window.validateAuthorNameFields();
+
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  test('form checkValidity() passes when all fields have valid values', () => {
+    const form = document.getElementById('form-mde');
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    titleInput.value = 'Valid Dataset Title';
+    lastname.value = 'Doe';
+    firstname.value = 'John';
+
+    window.validateTitleField();
+    window.validateAuthorNameFields();
+
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  test('validateAllMandatoryFields calls title and author validation', () => {
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    titleInput.value = '   ';
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    // validateAllMandatoryFields should trigger all sub-validations
+    window.validateAllMandatoryFields();
+
+    expect(titleInput.classList.contains('is-invalid')).toBe(true);
+    expect(lastname.classList.contains('is-invalid')).toBe(true);
+    expect(firstname.classList.contains('is-invalid')).toBe(true);
+  });
+});

--- a/tests/js/whitespaceValidation.test.js
+++ b/tests/js/whitespaceValidation.test.js
@@ -608,7 +608,10 @@ describe('validateTitleField and validateAuthorNameFields integration', () => {
     expect(form.checkValidity()).toBe(true);
   });
 
-  test('validateAllMandatoryFields calls title and author validation', () => {
+  test('validateAllMandatoryFields does NOT mark empty title/author fields as invalid on its own', () => {
+    // validateAllMandatoryFields() must NOT call validateTitleField/validateAuthorNameFields
+    // because that would turn fields red on page load before user interaction.
+    // These functions are called explicitly in submitHandler.handleSubmit() instead.
     const titleInput = document.getElementById('input-resourceinformation-title');
     const lastname = document.getElementById('input-author-lastname');
     const firstname = document.getElementById('input-author-firstname');
@@ -617,8 +620,27 @@ describe('validateTitleField and validateAuthorNameFields integration', () => {
     lastname.value = '   ';
     firstname.value = '   ';
 
-    // validateAllMandatoryFields should trigger all sub-validations
     window.validateAllMandatoryFields();
+
+    // Fields must NOT be marked invalid by validateAllMandatoryFields()
+    expect(titleInput.classList.contains('is-invalid')).toBe(false);
+    expect(lastname.classList.contains('is-invalid')).toBe(false);
+    expect(firstname.classList.contains('is-invalid')).toBe(false);
+  });
+
+  test('validateTitleField and validateAuthorNameFields must be called explicitly before submit', () => {
+    // This mirrors the submitHandler.handleSubmit() flow:
+    // call validateTitleField() and validateAuthorNameFields() before checkValidity()
+    const titleInput = document.getElementById('input-resourceinformation-title');
+    const lastname = document.getElementById('input-author-lastname');
+    const firstname = document.getElementById('input-author-firstname');
+
+    titleInput.value = '   ';
+    lastname.value = '   ';
+    firstname.value = '   ';
+
+    window.validateTitleField();
+    window.validateAuthorNameFields();
 
     expect(titleInput.classList.contains('is-invalid')).toBe(true);
     expect(lastname.classList.contains('is-invalid')).toBe(true);


### PR DESCRIPTION
This pull request improves the validation of mandatory form fields, specifically focusing on the resource title and author name fields. It ensures that these fields do not accept empty or whitespace-only input, provides user feedback, and updates the changelog to reflect these fixes.

## Changes
### Form validation improvements
* Added real-time and on-blur validation for the resource title input (`input-resourceinformation-title`), ensuring it cannot be empty or whitespace-only and providing user feedback using `setCustomValidity()` and visual cues.
* Implemented similar validation for the first author's last name and first name fields (`input-author-lastname`, `input-author-firstname`), marking them as invalid if left empty or with only whitespace, and displaying appropriate feedback.
* Integrated these new validation functions into the overall form validation flow (`validateAllMandatoryFields`) to ensure they are checked when the form is validated.
* Updated event listeners to trigger validation on blur and input events for the relevant fields, ensuring immediate feedback during user interaction.

### Changelog update
* Added a changelog entry noting the fix for inconsistent validation of the title field.

### Exports
* Exposed the new validation functions (`validateTitleField`, `validateAuthorNameFields`) for use in other modules or tests.

## Notes for Reviewer
None.

## Checklist

### Code Quality
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] My changes do not create new warnings in the browser console.

### Documentation
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide ('./doc/help.html') has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation ('./api/v2/docs') has been updated.
- [x] If a new feature was added or a bug fixed, the changelog ('./doc/changelog.html') has been updated.

### Testing
- [x] If needed, Playwright tests have been updated or added.
- [x] If needed, unit tests have been updated or added.
- [x] If needed, jest tests have been updated or added.


## Known Issues
None.
