### PR TITLE
docs(help): standardize 'data set' -> 'dataset' in doc/help.html

### DIFF
--- a/doc/help.html
+++ b/doc/help.html
@@ -180,7 +180,7 @@ include_once "../settings.php";
             <div id="help-resourceinformation" class="section-content">
                 <div id="help-resourceinformation-fg">
                     <h3>Resource Information</h3>
-                    <p>Please specify general metadata for the data set here. Mandatory
+                    <p>Please specify general metadata for the dataset here. Mandatory
                         fields are: Publication Year, Resource Type, Language of dataset, Title.
                     </p>
                     <p>By default, GFZ Data Services is the publisher. If this should not be the case, e.g. in some
@@ -292,7 +292,7 @@ include_once "../settings.php";
             <?php if ($showLicense ?? true): ?>
             <div id="help-rights" class="section-content">
                 <h3>Licenses and Rights</h3>                
-                <p>Rights information for the data set. Following the Guidelines for the Handling of Research Data
+                <p>Rights information for the dataset. Following the Guidelines for the Handling of Research Data
                     of the GFZ German Research Centre for Geosciences for open science, we recommend a Creative
                     Commons Attribution 4.0 (CC-BY) license whenever possible.</p>
                 <p>Please choose between:</p>
@@ -708,7 +708,7 @@ include_once "../settings.php";
                         <li>Please provide a technical description of the data generation (e.g. sampling method,
                             location, method of analysis, detection limits, data processing steps, conversions,
                             etc.), partners/partner institutions, and a summary of datasets included in this data
-                            publication (e.g. “7 boreholes reaching depths from 2-14 m” or “This data set
+                            publication (e.g. “7 boreholes reaching depths from 2-14 m” or “This dataset
                             encompasses broadband seismic data from c. 20 stations in Northern Chile, recorded since
                             2006” or “… paleomagnetic and rock magnetic dataset from two Calypso giant piston cores
                             collected at the crest of the Bellsund (GS191-01PC) and Isfjorden (GS191-02PC) sediment
@@ -875,9 +875,9 @@ include_once "../settings.php";
                 <div id="help-dates-fg">
                     <h3>Dates</h3>
                     <p>
-                        This group of fields refers to important data in the life cycle of the data set. Please
+                        This group of fields refers to important data in the life cycle of the dataset. Please
                         enter the information as precisely as possible to ensure the chronological classification
-                        and availability of the data set.
+                        and availability of the dataset.
                     </p>
                 </div>
                 <div id="help-date-created">


### PR DESCRIPTION
## Summary

\`doc/help.html\` had five \"data set\" occurrences alongside ~40 existing \"dataset\" occurrences. Standardize on \"dataset\" (the spelling used everywhere else in the help page and the UI) per #1058.

Locations updated:
- line 183 (general metadata intro)
- line 295 (rights information)
- line 711 (publication example)
- lines 878-880 (life-cycle description)

Closes #1058

## Testing

Docs-only change in a static help HTML file.