### PR TITLE
Feature: limit the selection of keywords shown in the GCMD trees

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -16,6 +16,8 @@
                     <li><strong>Features:</strong>
                         <ul>
                             <li>Automatic prefill of fields if a valid DOI is provided</li>
+                            <li>ELMOGEM version has a special selection of the GCMD science keywords, that are relevant for gravity modelling</li>
+
                         </ul>
                     </li>
                     <li><strong>Fixes:</strong>

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -697,7 +697,6 @@ $(document).ready(function () {
             'https://gcmd.earthdata.nasa.gov/kms/concept/8fb5ea8a-96ba-47cf-91cd-c7b64fbcd54a', // EARTH SCIENCE SERVICES > MODELS > SPHERICAL HARMONIC MODELS
             'https://gcmd.earthdata.nasa.gov/kms/concept/97576e51-28b5-4ae0-af33-fbb00fd5996b', // EARTH SCIENCE SERVICES > MODELS > MASS CONCENTRATION (MASCON) MODELS
             'https://gcmd.earthdata.nasa.gov/kms/concept/b8615aad-d2eb-45a3-98a7-4adac5bdf5a5', // EARTH SCIENCE SERVICES > MODELS > EARTH SCIENCE REANALYSES/ASSIMILATION MODELS
-            'https://gcmd.earthdata.nasa.gov/kms/concept/bc640e63-70c1-4228-b2dc-6aa1ac6edfa6', // EARTH SCIENCE > SOLID EARTH > GEODETICS > ELLIPSOID CHARACTERISTICS
             'https://gcmd.earthdata.nasa.gov/kms/concept/5498572c-aaed-4c08-8aad-8b297057e9c9', // EARTH SCIENCE > SOLID EARTH > GEODETICS
             'https://gcmd.earthdata.nasa.gov/kms/concept/221386f6-ef9b-4990-82b3-f990b0fe39fa', // EARTH SCIENCE > SOLID EARTH > GRAVITY/GRAVITATIONAL FIELD
             'https://gcmd.earthdata.nasa.gov/kms/concept/ad09b215-e837-4d9f-acbc-2b45e5b81825'  // EARTH SCIENCE > OCEANS > MARINE GEOPHYSICS > MARINE GRAVITY FIELD

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -674,7 +674,15 @@ $(document).ready(function () {
      * TODO: replace null placeholders with the desired GCMD concept URIs.
      */
     const GGM_THESAURUS_ROOT_NODES = {
-        // science_keywords: 'https://gcmd.earthdata.nasa.gov/kms/concept/...', // e.g. "Solid Earth"
+        science_keywords: [
+            'https://gcmd.earthdata.nasa.gov/kms/concept/8fb5ea8a-96ba-47cf-91cd-c7b64fbcd54a', // EARTH SCIENCE SERVICES > MODELS > SPHERICAL HARMONIC MODELS
+            'https://gcmd.earthdata.nasa.gov/kms/concept/97576e51-28b5-4ae0-af33-fbb00fd5996b', // EARTH SCIENCE SERVICES > MODELS > MASS CONCENTRATION (MASCON) MODELS
+            'https://gcmd.earthdata.nasa.gov/kms/concept/b8615aad-d2eb-45a3-98a7-4adac5bdf5a5', // EARTH SCIENCE SERVICES > MODELS > EARTH SCIENCE REANALYSES/ASSIMILATION MODELS
+            'https://gcmd.earthdata.nasa.gov/kms/concept/bc640e63-70c1-4228-b2dc-6aa1ac6edfa6', // EARTH SCIENCE > SOLID EARTH > GEODETICS > ELLIPSOID CHARACTERISTICS
+            'https://gcmd.earthdata.nasa.gov/kms/concept/5498572c-aaed-4c08-8aad-8b297057e9c9', // EARTH SCIENCE > SOLID EARTH > GEODETICS
+            'https://gcmd.earthdata.nasa.gov/kms/concept/221386f6-ef9b-4990-82b3-f990b0fe39fa', // EARTH SCIENCE > SOLID EARTH > GRAVITY/GRAVITATIONAL FIELD
+            'https://gcmd.earthdata.nasa.gov/kms/concept/ad09b215-e837-4d9f-acbc-2b45e5b81825'  // EARTH SCIENCE > OCEANS > MARINE GEOPHYSICS > MARINE GRAVITY FIELD
+        ]
         // platforms: null,
         // instruments: null,
     };

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -203,6 +203,26 @@ function loadKeywordsForConfig(config, response) {
                 console.error('No valid rootNodes found in', config.apiEndpoint);
                 return;
             }
+
+            // Remove any collected node that is already reachable as a descendant of
+            // another collected node (e.g. both GEODETICS and its child ELLIPSOID
+            // CHARACTERISTICS are listed). Keeping a child as a separate top-level
+            // entry would make it appear twice in the tree — once inside its parent
+            // and once as a peer — producing duplicate breadcrumb paths in the whitelist.
+            function isDescendantInSubtree(nodeId, subtreeChildren) {
+                if (!Array.isArray(subtreeChildren)) return false;
+                for (var i = 0; i < subtreeChildren.length; i++) {
+                    if (subtreeChildren[i].id === nodeId) return true;
+                    if (isDescendantInSubtree(nodeId, subtreeChildren[i].children)) return true;
+                }
+                return false;
+            }
+            collected = collected.filter(function (candidate) {
+                return !collected.some(function (other) {
+                    return other !== candidate && isDescendantInSubtree(candidate.id, other.children || []);
+                });
+            });
+
             filteredData = collected;
         } else if (config.rootNodeId) {
             var sel = findNodeById(availableNodes, config.rootNodeId);

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -739,15 +739,13 @@ $(document).ready(function () {
                     modalContainer.innerHTML += generateModal(item.key, config, item.displayName);
                     isFirst = false;
 
-                    // Determine root node: GGMs override takes priority, then the static config value.
-                    const ggmsRootNodeId = showGGMsProperties
+                    // Build keywordConfigurations entry for this thesaurus.
+                    // GGMs overrides (array → rootNodes, string → rootNodeId) take priority
+                    // over any static values in THESAURUS_CONFIG when the feature is active.
+                    const ggmsOverride = showGGMsProperties
                         ? GGM_THESAURUS_ROOT_NODES[item.key]
                         : undefined;
-                    const effectiveRootNodeId = ggmsRootNodeId !== undefined
-                        ? ggmsRootNodeId
-                        : config.rootNodeId;
 
-                    // Build keywordConfigurations entry for this thesaurus
                     const entry = {
                         inputId: '#' + config.inputId,
                         apiEndpoint: config.apiEndpoint,
@@ -756,8 +754,17 @@ $(document).ready(function () {
                         selectedKeywordsListId: config.selectedListId,
                         modalId: '#' + config.modalId,
                     };
-                    if (effectiveRootNodeId) entry.rootNodeId = effectiveRootNodeId;
-                    if (config.rootNodes) entry.rootNodes = config.rootNodes;
+
+                    if (Array.isArray(ggmsOverride)) {
+                        entry.rootNodes = ggmsOverride;
+                    } else if (typeof ggmsOverride === 'string') {
+                        entry.rootNodeId = ggmsOverride;
+                    } else {
+                        // No GGMs override — fall back to static config values.
+                        if (config.rootNodes) entry.rootNodes = config.rootNodes;
+                        if (config.rootNodeId) entry.rootNodeId = config.rootNodeId;
+                    }
+
                     keywordConfigurations.push(entry);
                 });
 

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -664,6 +664,20 @@ $(document).ready(function () {
     const features = window.ELMO_FEATURES || {};
     const showThesauri = features.showThesauri !== false;
     const showMslVocabs = features.showMslVocabs === true;
+    const showGGMsProperties = features.showGGMsProperties === true;
+
+    /**
+     * GGMs-specific root node constraints that narrow each thesaurus tree
+     * when ELMO_FEATURES.showGGMsProperties is enabled.
+     * Set to null to keep a thesaurus unrestricted; set to a concept URI to
+     * limit it to that subtree.
+     * TODO: replace null placeholders with the desired GCMD concept URIs.
+     */
+    const GGM_THESAURUS_ROOT_NODES = {
+        // science_keywords: 'https://gcmd.earthdata.nasa.gov/kms/concept/...', // e.g. "Solid Earth"
+        // platforms: null,
+        // instruments: null,
+    };
 
     // MSL root-Lists (unchanged, separate feature)
     const generalRoots = [
@@ -717,15 +731,26 @@ $(document).ready(function () {
                     modalContainer.innerHTML += generateModal(item.key, config, item.displayName);
                     isFirst = false;
 
+                    // Determine root node: GGMs override takes priority, then the static config value.
+                    const ggmsRootNodeId = showGGMsProperties
+                        ? GGM_THESAURUS_ROOT_NODES[item.key]
+                        : undefined;
+                    const effectiveRootNodeId = ggmsRootNodeId !== undefined
+                        ? ggmsRootNodeId
+                        : config.rootNodeId;
+
                     // Build keywordConfigurations entry for this thesaurus
-                    keywordConfigurations.push({
+                    const entry = {
                         inputId: '#' + config.inputId,
                         apiEndpoint: config.apiEndpoint,
                         jsTreeId: '#' + config.jsTreeId,
                         searchInputId: '#' + config.searchInputId,
                         selectedKeywordsListId: config.selectedListId,
                         modalId: '#' + config.modalId,
-                    });
+                    };
+                    if (effectiveRootNodeId) entry.rootNodeId = effectiveRootNodeId;
+                    if (config.rootNodes) entry.rootNodes = config.rootNodes;
+                    keywordConfigurations.push(entry);
                 });
 
                 // Initialize Tagify for each configuration

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -671,7 +671,6 @@ $(document).ready(function () {
      * when ELMO_FEATURES.showGGMsProperties is enabled.
      * Set to null to keep a thesaurus unrestricted; set to a concept URI to
      * limit it to that subtree.
-     * TODO: replace null placeholders with the desired GCMD concept URIs.
      */
     const GGM_THESAURUS_ROOT_NODES = {
         science_keywords: [

--- a/tests/js/thesauri.test.js
+++ b/tests/js/thesauri.test.js
@@ -952,6 +952,139 @@ describe('thesauri.js — GGMs root node filtering', () => {
       // logged an error and returned early without building a whitelist.
       expect(input._tagify.settings.whitelist.length).toBeGreaterThan(0);
     });
+
+    // ── overlap / deduplication ─────────────────────────────────────────────
+
+    test('when rootNodes contains both a parent and its child, the child is not promoted to a separate top-level entry', (done) => {
+      // Simulate rootNodes = [GEODETICS, ELLIPSOID_CHARACTERISTICS] — a parent and its own child.
+      // The child must NOT appear at top level alongside its parent; it must only appear
+      // as a child of GEODETICS — otherwise it gets two breadcrumb paths in the whitelist.
+      const overlapIds = ['uri:geodetics', 'uri:ellipsoid']; // parent + its child
+
+      document.body.innerHTML = `
+        <div id="thesaurusKeywordsFormGroup" style="display: none;">
+          <div class="accordion p-2" id="accordionThesauri"></div>
+        </div>
+        <div id="thesaurusModalsContainer"></div>
+      `;
+
+      $.getJSON = jest.fn((url, cb) => {
+        if (url === 'api/v2/vocabs/thesauri/availability') {
+          return {
+            done: jest.fn(function (fn) { fn({ science_keywords: { available: true, displayName: 'Science Keywords' } }); return this; }),
+            fail: jest.fn().mockReturnThis(),
+          };
+        }
+        if (typeof cb === 'function') cb(mockScienceKeywordsVocabulary);
+        return { fail: jest.fn().mockReturnThis() };
+      });
+
+      const rawScript = fs.readFileSync(path.resolve(__dirname, '../../js/thesauri.js'), 'utf8');
+      const patchedScript = rawScript.replace(
+        /const GGM_THESAURUS_ROOT_NODES\s*=\s*\{[\s\S]*?\};/,
+        `const GGM_THESAURUS_ROOT_NODES = { science_keywords: ${JSON.stringify(overlapIds)} };`
+      );
+      window.eval(transformThesauriScript(patchedScript));
+
+      $(document).ready(() => {
+        document.dispatchEvent(new Event('translationsLoaded'));
+
+        const modal = document.querySelector('#modal-sciencekeyword');
+        if (modal) modal.dispatchEvent(new Event('show.bs.modal'));
+
+        const tree = $('#jstree-sciencekeyword').jstree(true);
+        const topLevelIds = (tree._data || []).map(n => n.id);
+
+        // ELLIPSOID CHARACTERISTICS must NOT appear at the top level — it is already a child of GEODETICS
+        expect(topLevelIds).not.toContain('uri:ellipsoid');
+        // GEODETICS is the only top-level node (it's the ancestor that covers both)
+        expect(topLevelIds).toContain('uri:geodetics');
+
+        // Whitelist should contain ONLY the nested path, not a standalone "ELLIPSOID CHARACTERISTICS"
+        const input = document.getElementById('input-sciencekeyword');
+        const whitelistValues = input._tagify.settings.whitelist.map(w => w.value);
+        expect(whitelistValues).toContain('GEODETICS > ELLIPSOID CHARACTERISTICS'); // deep canonical path ✓
+        expect(whitelistValues).not.toContain('ELLIPSOID CHARACTERISTICS');          // standalone duplicate ✗
+
+        done();
+      });
+    }, 5000);
+
+    // ── focus-trigger lazy loading ────────────────────────────────────────
+
+    test('Tagify input focus also produces a filtered tree and whitelist (focus-trigger path)', (done) => {
+      // Reset state so lazy loading has not fired yet for this sub-test.
+      // Re-run setupEnvironment WITHOUT dispatching the modal event so the
+      // vocabulary data has not been loaded when we fire focus.
+      document.body.innerHTML = `
+        <div id="thesaurusKeywordsFormGroup" style="display: none;">
+          <div class="accordion p-2" id="accordionThesauri"></div>
+        </div>
+        <div id="thesaurusModalsContainer"></div>
+      `;
+
+      $.getJSON = jest.fn((url, cb) => {
+        if (url === 'api/v2/vocabs/thesauri/availability') {
+          return {
+            done: jest.fn(function (fn) { fn({ science_keywords: { available: true, displayName: 'Science Keywords' } }); return this; }),
+            fail: jest.fn().mockReturnThis(),
+          };
+        }
+        if (typeof cb === 'function') cb(mockScienceKeywordsVocabulary);
+        return { fail: jest.fn().mockReturnThis() };
+      });
+
+      const rawScript = fs.readFileSync(path.resolve(__dirname, '../../js/thesauri.js'), 'utf8');
+      const patchedScript = rawScript.replace(
+        /const GGM_THESAURUS_ROOT_NODES\s*=\s*\{[\s\S]*?\};/,
+        `const GGM_THESAURUS_ROOT_NODES = { science_keywords: ${JSON.stringify(GGM_ROOT_IDS)} };`
+      );
+      window.eval(transformThesauriScript(patchedScript));
+
+      $(document).ready(() => {
+        document.dispatchEvent(new Event('translationsLoaded'));
+
+        // Tree must NOT be loaded yet (no modal open)
+        expect($('#jstree-sciencekeyword').jstree(true)).toBeUndefined();
+
+        // Trigger via focus, same as when a user starts typing before opening the modal
+        const input = document.getElementById('input-sciencekeyword');
+        const tagifyWrapper = input.closest('.tagify') || input.parentElement?.querySelector('.tagify') || input;
+        tagifyWrapper.dispatchEvent(new Event('focus', { bubbles: false }));
+
+        // Tree must now be initialised and must be filtered
+        const tree = $('#jstree-sciencekeyword').jstree(true);
+        expect(tree).toBeDefined();
+        const ids = tree.allNodeIds();
+
+        GGM_ROOT_IDS.forEach(id => expect(ids).toContain(id));             // listed roots present
+        expect(ids).toContain('uri:ellipsoid');                             // child of listed root present
+        expect(ids).not.toContain('uri:topography');                        // non-listed sibling absent
+        expect(ids).not.toContain('uri:climate-models');                    // non-listed sibling absent
+
+        done();
+      });
+    }, 5000);
+
+    // ── pre-population round-trip ─────────────────────────────────────────
+
+    test('a value saved in a previous session is present in the filtered whitelist (round-trip compatibility)', () => {
+      // "GEODETICS > ELLIPSOID CHARACTERISTICS" is the correct deep breadcrumb path for a
+      // concept that lives inside one of the GGMs root subtrees. It must appear verbatim in
+      // the filtered Tagify whitelist so that programmatic addTags (used by XML→input mapping)
+      // does not render the tag as invalid.
+      const input = document.getElementById('input-sciencekeyword');
+      const whitelistValues = input._tagify.settings.whitelist.map(w => w.value);
+
+      // The deep path (canonical breadcrumb built from the filtered tree) must exist
+      expect(whitelistValues).toContain('GEODETICS > ELLIPSOID CHARACTERISTICS');
+      expect(whitelistValues).toContain('MARINE GRAVITY FIELD > OCEAN DEPTH');
+      expect(whitelistValues).toContain('SPHERICAL HARMONIC MODELS');
+
+      // Simulate what mappingXmlToInputFields does: programmatically add a previously saved tag
+      input._tagify.addTags(['GEODETICS > ELLIPSOID CHARACTERISTICS']);
+      expect(input._tagify.value.some(v => v.value === 'GEODETICS > ELLIPSOID CHARACTERISTICS')).toBe(true);
+    });
   });
 
   describe('with GGMsProperties disabled', () => {

--- a/tests/js/thesauri.test.js
+++ b/tests/js/thesauri.test.js
@@ -696,3 +696,288 @@ describe('thesauri.js — showLoadingSpinner / hideLoadingSpinner / loadThesauru
   });
 
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GGMs thesaurus root-node limiting
+// Tests that when showGGMsProperties is enabled the science_keywords tree is
+// filtered to only the nodes listed in GGM_THESAURUS_ROOT_NODES, their
+// children are preserved, and nodes NOT in the list are excluded.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('thesauri.js — GGMs root node filtering', () => {
+  let $;
+  let exports;
+
+  // ── mock data ──────────────────────────────────────────────────────────────
+
+  /**
+   * Simulated GCMD science-keywords vocabulary response.
+   *
+   * Tree shape:
+   *   Science Keywords
+   *     EARTH SCIENCE
+   *       SOLID EARTH
+   *         GEODETICS                        ← in GGM list
+   *           ELLIPSOID CHARACTERISTICS      ← child of listed node
+   *         TOPOGRAPHY                       ← NOT in GGM list
+   *       OCEANS
+   *         MARINE GEOPHYSICS
+   *           MARINE GRAVITY FIELD           ← in GGM list
+   *             OCEAN DEPTH                  ← child of listed node
+   *     EARTH SCIENCE SERVICES
+   *       MODELS
+   *         SPHERICAL HARMONIC MODELS        ← in GGM list
+   *         CLIMATE MODELS                   ← NOT in GGM list
+   */
+  const GGM_ROOT_IDS = [
+    'uri:geodetics',
+    'uri:marine-gravity-field',
+    'uri:spherical-harmonic-models',
+  ];
+
+  const mockScienceKeywordsVocabulary = {
+    data: [
+      {
+        id: 'uri:science-keywords', text: 'Science Keywords', children: [
+          {
+            id: 'uri:earth-science', text: 'EARTH SCIENCE', children: [
+              {
+                id: 'uri:solid-earth', text: 'SOLID EARTH', children: [
+                  {
+                    id: 'uri:geodetics', text: 'GEODETICS', children: [
+                      { id: 'uri:ellipsoid', text: 'ELLIPSOID CHARACTERISTICS', children: [] },
+                    ],
+                  },
+                  {
+                    id: 'uri:topography', text: 'TOPOGRAPHY', children: [],
+                  },
+                ],
+              },
+              {
+                id: 'uri:oceans', text: 'OCEANS', children: [
+                  {
+                    id: 'uri:marine-geophysics', text: 'MARINE GEOPHYSICS', children: [
+                      {
+                        id: 'uri:marine-gravity-field', text: 'MARINE GRAVITY FIELD', children: [
+                          { id: 'uri:ocean-depth', text: 'OCEAN DEPTH', children: [] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'uri:earth-science-services', text: 'EARTH SCIENCE SERVICES', children: [
+              {
+                id: 'uri:models', text: 'MODELS', children: [
+                  { id: 'uri:spherical-harmonic-models', text: 'SPHERICAL HARMONIC MODELS', children: [] },
+                  { id: 'uri:climate-models', text: 'CLIMATE MODELS', children: [] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  // ── shared setup ──────────────────────────────────────────────────────────
+
+  function setupEnvironment(done, featureFlags = {}) {
+    document.body.innerHTML = `
+      <div id="thesaurusKeywordsFormGroup" style="display: none;">
+        <div class="accordion p-2" id="accordionThesauri"></div>
+      </div>
+      <div id="thesaurusModalsContainer"></div>
+    `;
+
+    $ = require('jquery');
+    global.$ = $;
+    global.jQuery = $;
+    window.$ = $;
+    window.jQuery = $;
+
+    // Minimal jstree mock that tracks nodes loaded into it
+    (function ($) {
+      $.fn.jstree = function (arg) {
+        if (arg === undefined || arg === true) return this.data('jstree');
+        if (typeof arg === 'object') {
+          const inst = {
+            _data: arg.core.data,
+            allNodeIds() {
+              const ids = [];
+              function walk(nodes) {
+                if (!Array.isArray(nodes)) return;
+                nodes.forEach(n => { ids.push(n.id); walk(n.children); });
+              }
+              walk(this._data);
+              return ids;
+            },
+          };
+          this.data('jstree', inst);
+          return this;
+        }
+        return this;
+      };
+    })($);
+
+    global.Tagify = MockTagify;
+    global.translations = {
+      keywords: { thesaurus: { label: 'KW', unavailable: 'err' }, searchPlaceholder: 'Search', selectedKeywords: 'Selected' },
+      general: { loading: 'Loading' },
+    };
+
+    window.ELMO_FEATURES = {
+      showThesauri: true,
+      showMslVocabs: false,
+      showGGMsProperties: featureFlags.showGGMsProperties ?? true,
+    };
+
+    $.getJSON = jest.fn((url, cb) => {
+      if (url === 'api/v2/vocabs/thesauri/availability') {
+        return {
+          done: jest.fn(function (fn) { fn({ science_keywords: { available: true, displayName: 'Science Keywords' } }); return this; }),
+          fail: jest.fn().mockReturnThis(),
+        };
+      }
+      // Vocabulary endpoint — return the mock tree
+      if (typeof cb === 'function') cb(mockScienceKeywordsVocabulary);
+      return { fail: jest.fn().mockReturnThis() };
+    });
+
+    // Patch GGM_THESAURUS_ROOT_NODES inside the evaluated script by injecting
+    // it into the source before eval so the test controls the list.
+    const rawScript = fs.readFileSync(path.resolve(__dirname, '../../js/thesauri.js'), 'utf8');
+    const patchedScript = rawScript
+      // Replace the hard-coded URI list with our test IDs
+      .replace(
+        /const GGM_THESAURUS_ROOT_NODES\s*=\s*\{[\s\S]*?\};/,
+        `const GGM_THESAURUS_ROOT_NODES = { science_keywords: ${JSON.stringify(GGM_ROOT_IDS)} };`
+      );
+
+    window.eval(transformThesauriScript(patchedScript));
+
+    $(document).ready(() => {
+      document.dispatchEvent(new Event('translationsLoaded'));
+      exports = window.__thesauriTestExports;
+
+      // Trigger lazy load so the tree is actually built
+      const modal = document.querySelector('#modal-sciencekeyword');
+      if (modal) modal.dispatchEvent(new Event('show.bs.modal'));
+
+      done();
+    });
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.Tagify;
+    delete global.translations;
+    delete window.ELMO_FEATURES;
+  });
+
+  // ── tests ─────────────────────────────────────────────────────────────────
+
+  describe('with GGMsProperties enabled', () => {
+    beforeEach((done) => setupEnvironment(done));
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      delete global.Tagify;
+      delete global.translations;
+      delete window.ELMO_FEATURES;
+    });
+
+    test('listed root nodes are present in the tree', () => {
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      const ids = tree.allNodeIds();
+      GGM_ROOT_IDS.forEach(id => {
+        expect(ids).toContain(id);
+      });
+    });
+
+    test('children of listed root nodes are present in the tree', () => {
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      const ids = tree.allNodeIds();
+      // ELLIPSOID CHARACTERISTICS is a child of GEODETICS (listed)
+      expect(ids).toContain('uri:ellipsoid');
+      // OCEAN DEPTH is a child of MARINE GRAVITY FIELD (listed)
+      expect(ids).toContain('uri:ocean-depth');
+    });
+
+    test('nodes NOT in GGM_ROOT_IDS and not their descendants are excluded', () => {
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      const ids = tree.allNodeIds();
+      // TOPOGRAPHY is a sibling of GEODETICS but not listed
+      expect(ids).not.toContain('uri:topography');
+      // CLIMATE MODELS is a sibling of SPHERICAL HARMONIC MODELS but not listed
+      expect(ids).not.toContain('uri:climate-models');
+    });
+
+    test('ancestor/container nodes that lead to listed nodes are NOT present (subtrees are detached)', () => {
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      const ids = tree.allNodeIds();
+      // The tree should start from the listed nodes themselves, not from the full hierarchy
+      expect(ids).not.toContain('uri:science-keywords');
+      expect(ids).not.toContain('uri:earth-science');
+      expect(ids).not.toContain('uri:solid-earth');
+    });
+
+    test('Tagify whitelist only contains paths reachable from listed nodes', () => {
+      const input = document.getElementById('input-sciencekeyword');
+      const whitelistValues = input._tagify.settings.whitelist.map(w => w.value);
+
+      // Paths from listed nodes and their children should be present
+      expect(whitelistValues.some(v => v.includes('GEODETICS'))).toBe(true);
+      expect(whitelistValues.some(v => v.includes('ELLIPSOID CHARACTERISTICS'))).toBe(true);
+      expect(whitelistValues.some(v => v.includes('MARINE GRAVITY FIELD'))).toBe(true);
+      expect(whitelistValues.some(v => v.includes('SPHERICAL HARMONIC MODELS'))).toBe(true);
+
+      // Paths from non-listed nodes must NOT appear
+      expect(whitelistValues.some(v => v.includes('TOPOGRAPHY'))).toBe(false);
+      expect(whitelistValues.some(v => v.includes('CLIMATE MODELS'))).toBe(false);
+    });
+
+    test('entry built for science_keywords uses rootNodes (array), not rootNodeId', () => {
+      // Verify the bug is fixed: an array override must not land on rootNodeId
+      const input = document.getElementById('input-sciencekeyword');
+      // The Tagify whitelist being scoped is enough proof, but we also confirm
+      // no fatal "Root node with ID Array(...) not found" path was taken by
+      // checking the tree was actually initialised (it would be null on that error).
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      expect(tree).toBeDefined();
+      expect(tree).not.toBeNull();
+      // If rootNodeId had received the array, loadKeywordsForConfig would have
+      // logged an error and returned early without building a whitelist.
+      expect(input._tagify.settings.whitelist.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('with GGMsProperties disabled', () => {
+    beforeEach((done) => setupEnvironment(done, { showGGMsProperties: false }));
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      delete global.Tagify;
+      delete global.translations;
+      delete window.ELMO_FEATURES;
+    });
+
+    test('full vocabulary tree is loaded without filtering when feature is off', () => {
+      const tree = $('#jstree-sciencekeyword').jstree(true);
+      const ids = tree.allNodeIds();
+      // All nodes including non-GGM ones should be present
+      expect(ids).toContain('uri:topography');
+      expect(ids).toContain('uri:climate-models');
+      expect(ids).toContain('uri:science-keywords');
+    });
+
+    test('Tagify whitelist includes non-GGM paths when feature is off', () => {
+      const input = document.getElementById('input-sciencekeyword');
+      const whitelistValues = input._tagify.settings.whitelist.map(w => w.value);
+      expect(whitelistValues.some(v => v.includes('TOPOGRAPHY'))).toBe(true);
+      expect(whitelistValues.some(v => v.includes('CLIMATE MODELS'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
According to K., in ELMOGEM the choice of the GCMD Science keywords should be limited to the concepts, that are relevant for the gravity field modelling. This implementation implies that flexibility in the list of concepts and possible limitation of other keyword vocabularies.

This alligns with ELMO philosophy: user has the choice, but from the valid options. 

Closes #927 

## Changes
added a rewrite statement to the `initThesauri` function. the function supplies values from `GGM_THESAURUS_ROOT_NODES` as `rootNodesIds` Supported by jest tests. 

## Notes for Reviewer
Open GCMD science keywords: the choice should be more compact. Please ensure the search, tagify sync and related functions are unchanged. 

EELMO generic should be unchanged.

## Checklist

### Code Quality
- [ ] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] My changes do not create new warnings in the browser console.

### Documentation
- [ ] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide ('./doc/help.html') has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation ('./api/v2/docs') has been updated.
- [x] If a new feature was added or a bug fixed, the changelog ('./doc/changelog.html') has been updated.

### Testing
- [ ] If needed, Playwright tests have been updated or added.
- [ ] If needed, unit tests have been updated or added.
- [x] If needed, jest tests have been updated or added.


## Known Issues
[What lower priority problems remain?]
