### PR TITLE
hotfix: Add fallback from ICGEM to standard XML for non-GGM datasets

### DIFF
--- a/save/save_data.php
+++ b/save/save_data.php
@@ -71,9 +71,16 @@ function generateAndOutputXml($resource_id)
     try {
         $controller = new DatasetController();
         $ICGEMcontroller = new ICGEMController();
-        $xmlString = $showGGMsProperties
-            ? $ICGEMcontroller->createICGEMxml($resource_id)
-            : $controller->envelopeXmlAsString($connection, $resource_id);
+        if ($showGGMsProperties) {
+            try {
+                $xmlString = $ICGEMcontroller->createICGEMxml($resource_id);
+            } catch (\Throwable $e) {
+                error_log("[SAVE] ICGEM XML failed, fallback to standard XML for resource_id=$resource_id: " . $e->getMessage());
+                $xmlString = $controller->envelopeXmlAsString($connection, $resource_id);
+            }
+        } else {
+            $xmlString = $controller->envelopeXmlAsString($connection, $resource_id);
+        }
     } catch (\Throwable $e) {
         error_log("[SAVE] XML generation threw: " . $e->getMessage());
         throw new \RuntimeException(


### PR DESCRIPTION
#### Problem:
When $showGGMsProperties was active, the system attempted to generate ICGEM XML for all datasets after saving including Elmo Generic and MSL datasets that don't contain GGM data. This caused a 500 error during XML download, even though the database save was successful

#### Fix:
This PR adds a fallback in save/save_data.php: If ICGEM XML generation fails (because GGM data is missing), the system automatically generates standard XML instead.
