### PR TITLE
Hotfix: saving funder

### DIFF
--- a/js/eventhandlers/formgroups/fundingreference.js
+++ b/js/eventhandlers/formgroups/fundingreference.js
@@ -30,6 +30,20 @@ function escapeSelector(value) {
 $(document).ready(function () {
   const fundingreferenceGroup = $("#group-fundingreference");
 
+  function clearFunderHiddenFields(row) {
+    const $row = $(row);
+    $row.find('.inputFunderId').val('');
+    $row.find('.inputFunderIdTyp').val('');
+  }
+
+  fundingreferenceGroup.on('input blur', '.inputFunder', function () {
+    if ($(this).val().trim() !== '') {
+      return;
+    }
+
+    clearFunderHiddenFields($(this).closest('[funding-reference-row]'));
+  });
+
   function initialiseAutocomplete(input) {
     if (typeof setUpAutocompleteFunder === 'function' && input) {
       setUpAutocompleteFunder(input);

--- a/js/eventhandlers/formgroups/fundingreference.js
+++ b/js/eventhandlers/formgroups/fundingreference.js
@@ -30,12 +30,14 @@ function escapeSelector(value) {
 $(document).ready(function () {
   const fundingreferenceGroup = $("#group-fundingreference");
 
+  // Clear the hidden funder fields when the visible funder input is empty.
   function clearFunderHiddenFields(row) {
     const $row = $(row);
     $row.find('.inputFunderId').val('');
     $row.find('.inputFunderIdTyp').val('');
   }
 
+  // Keep hidden funder values in sync when the funder input is cleared.
   fundingreferenceGroup.on('input blur', '.inputFunder', function () {
     if ($(this).val().trim() !== '') {
       return;

--- a/tests/playwright/formgroups/funding-reference.spec.ts
+++ b/tests/playwright/formgroups/funding-reference.spec.ts
@@ -235,4 +235,28 @@ test.describe('Funding Reference form group', () => {
       await expect(rows).toHaveCount(initialCount);
     }
   });
+
+  test('clears hidden funder values when the visible funder input is cleared', async ({ page }) => {
+    const firstRow = page.locator(`${SELECTORS.formGroups.fundingReference} [funding-reference-row]`).first();
+    const funderInput = firstRow.locator('.inputFunder');
+    const funderIdInput = firstRow.locator('.inputFunderId');
+    const funderIdTypeInput = firstRow.locator('.inputFunderIdTyp');
+
+    await funderInput.click();
+    await funderInput.type('Muskelsvindfonden');
+
+    const dropdown = page.locator('ul.ui-autocomplete').filter({ hasText: 'Muskelsvindfonden' }).first();
+    await expect(dropdown).toBeVisible();
+    await dropdown.locator('li', { hasText: 'Muskelsvindfonden' }).first().click();
+
+    await expect(funderInput).toHaveValue('Muskelsvindfonden');
+    await expect(funderIdInput).toHaveValue('1100011641');
+    await expect(funderIdTypeInput).toHaveValue('crossref');
+
+    await funderInput.fill('');
+
+    await expect(funderInput).toHaveValue('');
+    await expect(funderIdInput).toHaveValue('');
+    await expect(funderIdTypeInput).toHaveValue('');
+  });
 });

--- a/tests/playwright/formgroups/funding-reference.spec.ts
+++ b/tests/playwright/formgroups/funding-reference.spec.ts
@@ -243,14 +243,14 @@ test.describe('Funding Reference form group', () => {
     const funderIdTypeInput = firstRow.locator('.inputFunderIdTyp');
 
     await funderInput.click();
-    await funderInput.type('Muskelsvindfonden');
+    await funderInput.type('Gordon');
 
-    const dropdown = page.locator('ul.ui-autocomplete').filter({ hasText: 'Muskelsvindfonden' }).first();
+    const dropdown = page.locator('ul.ui-autocomplete').filter({ hasText: 'Gordon and Betty Moore Foundation' }).first();
     await expect(dropdown).toBeVisible();
-    await dropdown.locator('li', { hasText: 'Muskelsvindfonden' }).first().click();
+    await dropdown.locator('li', { hasText: 'Gordon and Betty Moore Foundation' }).first().click();
 
-    await expect(funderInput).toHaveValue('Muskelsvindfonden');
-    await expect(funderIdInput).toHaveValue('1100011641');
+    await expect(funderInput).toHaveValue('Gordon and Betty Moore Foundation');
+    await expect(funderIdInput).toHaveValue('100000012');
     await expect(funderIdTypeInput).toHaveValue('crossref');
 
     await funderInput.fill('');


### PR DESCRIPTION
This pull request fixes a bug in the Funding Reference form group where hidden funder fields were not cleared when the visible funder input was emptied. As a result, outdated funder identifiers could still appear in the exported XML even though the funder name was removed in the UI.

## Changes

1. Added a small handler in the Funding Reference form group that:

- Clears the corresponding funderId and funderIdTyp hidden fields when the visible .inputFunder is emptied.
- Leaves the hidden fields untouched when the visible funder input still has a value.

2. Added a new Playwright-Test.

## Notes for Reviewer
The bug becomes visible in cases like these XML snippets:
1. Valid funding reference with full metadata:

```
<fundingReferences>
  <fundingReference>
    <funderName>GivingTuesday</funderName>
    <funderIdentifier
      schemeURI="https://www.crossref.org/services/funder-registry/"
      funderIdentifierType="Crossref Funder ID">
      https://doi.org/10.13039/100027863
    </funderIdentifier>
    <awardNumber awardURI="https://github.com/McNamara84/ernie">45201</awardNumber>
    <awardTitle>ali</awardTitle>
  </fundingReference>
</fundingReferences>
```


2. Problematic case: funder name cleared in the UI, identifier still present:

```
<fundingReferences>
  <fundingReference>
    <funderName/>
    <funderIdentifier
      schemeURI="https://www.crossref.org/services/funder-registry/"
      funderIdentifierType="Crossref Funder ID">
      https://doi.org/10.13039/100027863
    </funderIdentifier>
  </fundingReference>
</fundingReferences>
```

3. In a separate pull request I will also address two additional bugs and include the visioning changes there.
## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
None.