### PR TITLE
Fix: ORCID validation layout

### DIFF
--- a/css/gfz-cd.css
+++ b/css/gfz-cd.css
@@ -617,3 +617,17 @@ header .ms-auto.d-flex {
     height: 32px;
   }
 }
+
+/* Keep ORCID buttons aligned with the input height */
+#checkbox-author-contactperson+label,
+.orcid-search-btn,
+.orcid-help-icon {
+    min-height: calc(3.5rem + 2px);
+}
+
+.orcid-search-btn,
+.orcid-help-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/css/tagify-adj.css
+++ b/css/tagify-adj.css
@@ -30,6 +30,11 @@
     border-bottom-right-radius: 0;
 }
 
+.input-left-no-round-corners {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
 /* Makes the square corners round */
 .input-group-text {
     border-top-right-radius: 0.375rem !important;

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -9,13 +9,11 @@
         <div class="col-12 col-sm-12 col-md-5 col-lg-3 p-1">
           <div class="input-group has-validation">
             <!-- Toggle-Checkbox als Button (Bootstrap Toggle Button) -->
-            <div>
-              <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
-              <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
-                data-translate="contactPersons.toggleCheckbox">
-                Contact<br>Person
-              </label>
-            </div>
+            <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
+            <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
+              data-translate="contactPersons.toggleCheckbox">
+              Contact<br>Person
+            </label>
             <!-- ORCID Input Field -->
             <div class="form-floating flex-grow-1">
               <input type="text" class="form-control input-right-no-round-corners"

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -9,11 +9,13 @@
         <div class="col-12 col-sm-12 col-md-5 col-lg-3 p-1">
           <div class="input-group has-validation">
             <!-- Toggle-Checkbox als Button (Bootstrap Toggle Button) -->
-            <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
-            <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
-              data-translate="contactPersons.toggleCheckbox">
-              Contact<br>Person
-            </label>
+            <div class="input-group-append">
+              <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
+              <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
+                data-translate="contactPersons.toggleCheckbox">
+                Contact<br>Person
+              </label>
+            </div>
             <!-- ORCID Input Field -->
             <div class="form-floating flex-grow-1">
               <input type="text" class="form-control input-right-no-round-corners"
@@ -24,16 +26,20 @@
               </div>
             </div>
             <!-- ORCID Search Button -->
-            <button type="button" class="btn btn-outline-secondary orcid-search-btn input-with-help"
-              data-bs-toggle="modal" data-bs-target="#modal-orcid-search"
-              data-translate-title="orcidSearch.searchButtonTitle" title="Search ORCID by name"
-              aria-label="Search ORCID by name">
-              <i class="bi bi-search" aria-hidden="true"></i>
-            </button>
+            <div class="input-group-append">
+              <button type="button" class="btn btn-outline-secondary orcid-search-btn input-with-help"
+                data-bs-toggle="modal" data-bs-target="#modal-orcid-search"
+                data-translate-title="orcidSearch.searchButtonTitle" title="Search ORCID by name"
+                aria-label="Search ORCID by name">
+                <i class="bi bi-search" aria-hidden="true"></i>
+              </button>
+            </div>
             <!-- Help Icon -->
-            <span class="input-group-text">
-              <i class="bi bi-question-circle-fill" data-help-section-id="help-author-orcid"></i>
-            </span>
+            <div class="input-group-append">
+              <span class="input-group-text">
+                <i class="bi bi-question-circle-fill" data-help-section-id="help-author-orcid"></i>
+              </span>
+            </div>
           </div>
         </div>
         <!-- Input field Lastname Author -->

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -36,7 +36,7 @@
             </div>
             <!-- Help Icon -->
             <div class="input-group-append">
-              <span class="input-group-text">
+              <span class="input-group-text orcid-help-icon">
                 <i class="bi bi-question-circle-fill" data-help-section-id="help-author-orcid"></i>
               </span>
             </div>

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -9,11 +9,13 @@
         <div class="col-12 col-sm-12 col-md-5 col-lg-3 p-1">
           <div class="input-group has-validation">
             <!-- Toggle-Checkbox als Button (Bootstrap Toggle Button) -->
-            <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
-            <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
-              data-translate="contactPersons.toggleCheckbox">
-              Contact<br>Person
-            </label>
+            <div>
+              <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
+              <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
+                data-translate="contactPersons.toggleCheckbox">
+                Contact<br>Person
+              </label>
+            </div>
             <!-- ORCID Input Field -->
             <div class="form-floating flex-grow-1">
               <input type="text" class="form-control input-right-no-round-corners"

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -11,7 +11,7 @@
             <!-- Toggle-Checkbox als Button (Bootstrap Toggle Button) -->
             <div class="input-group-append">
               <input type="checkbox" class="btn-check" id="checkbox-author-contactperson" name="contacts[]" autocomplete="off">
-              <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce" for="checkbox-author-contactperson"
+              <label class="btn btn-outline-primary lh-sm round-corners-left con-reduce input-right-no-round-corners" for="checkbox-author-contactperson"
                 data-translate="contactPersons.toggleCheckbox">
                 Contact<br>Person
               </label>
@@ -27,7 +27,7 @@
             </div>
             <!-- ORCID Search Button -->
             <div class="input-group-append">
-              <button type="button" class="btn btn-outline-secondary orcid-search-btn input-with-help"
+              <button type="button" class="btn btn-outline-secondary orcid-search-btn input-with-help input-left-no-round-corners"
                 data-bs-toggle="modal" data-bs-target="#modal-orcid-search"
                 data-translate-title="orcidSearch.searchButtonTitle" title="Search ORCID by name"
                 aria-label="Search ORCID by name">


### PR DESCRIPTION
This pull request fixes the ORCID field issue where the validation message pushed everything down when an invalid value was entered.


## Changes
- fixed the ORCID validation message layout so it no longer breaks the field group
- adjusted ORCID button sizing to match the input field height
- corrected button corner styling for the contact person and ORCID search buttons

## Notes for Reviewer
None.

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
None.