### PR TITLE
Feature/map UI enhancement

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -22,6 +22,7 @@
                             <li>ELMOGEM version ingests the file format from GGM metadata into the Datacite property</li>
                             <li>ELMOGEM version can save the documents according to the ICGEM metadata schema</li>
                             <li>ELMOGEM version: the documents according to the ICGEM metadata schema can be uploaded into the editor</li>
+                            <li>Spacio-temporal coverage: the selection of rectangle is optimised</li>
 
 
                         </ul>

--- a/doc/help.html
+++ b/doc/help.html
@@ -927,6 +927,32 @@ include_once "../settings.php";
                         research data in our repository.
                     </p>
                 </div>
+                <div id="help-stc-fg-map">
+                    <h4>Using the Map</h4>
+                    <p>You can define the spatial coverage directly on the map. Open the map modal and select your preferred mode:</p>
+                    <ul>
+                        <li><strong>Marker:</strong> Click anywhere on the map to select a single point.</li>
+                        <li><strong>Rectangle:</strong> Left-click two points on the map to draw a bounding rectangle between them. Right-click at any time to cancel drawing.</li>
+                    </ul>
+                    <h5>Map Navigation</h5>
+                    <ul>
+                        <li><strong>Zoom In:</strong>
+                            <ul>
+                                <li>Scroll the mouse wheel while holding <kbd>Ctrl</kbd> (Windows) or <kbd>Cmd</kbd> (Mac).</li>
+                                <li>Click the <kbd>+</kbd> button.</li>
+                                <li>Double-left-click on the map.</li>
+                            </ul>
+                        </li>
+                        <li><strong>Zoom Out:</strong>
+                            <ul>
+                                <li>Scroll the mouse wheel backward while holding <kbd>Ctrl</kbd> (Windows) or <kbd>Cmd</kbd> (Mac).</li>
+                                <li>Click the <kbd>-</kbd> button.</li>
+                                <li>Double-right-click on the map.</li>
+                            </ul>
+                        </li>
+                        <li><strong>Place Search:</strong> Use the search bar to instantly jump and zoom into a specific location or address.</li>
+                    </ul>
+                </div>
                 <div id="help-tsc-geographicalcoverage">
                     <h4>Geographic Coverage</h4>
                     <p>You can add singles coordinates with <code>Latitude Min</code> and <code>Longitude Min</code>

--- a/formgroups/coverage.html
+++ b/formgroups/coverage.html
@@ -126,6 +126,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="label-stc-map" data-translate="coverage.map">Map</h5>
+                    <i class="bi bi-question-circle-fill" data-help-section-id="help-stc-fg-map"></i>
                     <br>&nbsp;&nbsp;&nbsp;
                     <div data-translate="coverage.mapInfo">(Please choose coordinates with rectangle or marker)
                     </div>

--- a/js/map.js
+++ b/js/map.js
@@ -262,6 +262,20 @@ $(document).ready(function () {
         self.previewRect.setBounds(new google.maps.LatLngBounds(sw, ne));
       }
     });
+
+    // Right-click cancels an in-progress rectangle and resets to initial drawing state.
+    this._map.addListener("rightclick", function () {
+      if (self._clickTimer !== null) {
+        clearTimeout(self._clickTimer);
+        self._clickTimer = null;
+      }
+      if (self.previewRect) {
+        self.previewRect.setMap(null);
+        self.previewRect = null;
+      }
+      self.rectState = null;
+      self.startLatLng = null;
+    });
   };
 
   /**

--- a/js/map.js
+++ b/js/map.js
@@ -38,7 +38,25 @@ $(document).ready(function () {
     // Adjust the map when the modal is shown
     $("#modal-stc-map").one("shown.bs.modal", function () {
       google.maps.event.trigger(map, "resize");
-      fitMapBounds();
+
+      var latMin = $currentRow.find("[id^=input-stc-latmin]").val();
+      var lngMin = $currentRow.find("[id^=input-stc-longmin]").val();
+      var latMax = $currentRow.find("[id^=input-stc-latmax]").val();
+      var lngMax = $currentRow.find("[id^=input-stc-longmax]").val();
+
+      if (latMin && lngMin) {
+        // Ensure overlay exists for this row (may not if coords were set programmatically)
+        var hasOverlay = drawnOverlays.some(function (item) { return item.rowId === rowId; });
+        if (!hasOverlay) {
+          updateMapOverlay(rowId, latMax, lngMax, latMin, lngMin);
+        } else {
+          fitMapBoundsForRow(rowId);
+        }
+      } else {
+        // No coordinates yet – reset to whole-planet view
+        map.setCenter({ lat: 20, lng: 0 });
+        map.setZoom(2);
+      }
     });
   });
 
@@ -81,8 +99,8 @@ $(document).ready(function () {
   function DrawingController(mapInstance) {
     /** @type {string|null} Current drawing mode: 'marker' | 'rectangle' | null */
     this.mode = "marker";
-    /** @type {boolean} Whether a rectangle drag is in progress */
-    this.isDrawing = false;
+    /** @type {string|null} Rectangle drawing state: null | 'started' */
+    this.rectState = null;
     /** @type {?google.maps.LatLng} Start position for rectangle drawing */
     this.startLatLng = null;
     /** @type {?google.maps.Rectangle} Temporary preview rectangle during drag */
@@ -152,7 +170,9 @@ $(document).ready(function () {
   };
 
   /**
-   * Sets up click, mousemove, and mouseup listeners on the map for drawing.
+   * Sets up click and mousemove listeners on the map for drawing.
+   * Rectangle drawing uses two clicks: first click sets the first corner,
+   * second click completes the rectangle. Any corner order is supported.
    * @private
    */
   DrawingController.prototype._setupMapListeners = function () {
@@ -165,38 +185,52 @@ $(document).ready(function () {
           map: self._map
         });
         self._emit("markercomplete", marker);
-      } else if (self.mode === "rectangle" && !self.isDrawing) {
-        self.isDrawing = true;
-        self.startLatLng = e.latLng;
-        self.previewRect = new google.maps.Rectangle({
-          bounds: new google.maps.LatLngBounds(e.latLng, e.latLng),
-          strokeColor: RECTANGLE_STYLE.strokeColor,
-          strokeOpacity: RECTANGLE_STYLE.strokeOpacity,
-          strokeWeight: RECTANGLE_STYLE.strokeWeight,
-          fillColor: RECTANGLE_STYLE.fillColor,
-          fillOpacity: RECTANGLE_STYLE.fillOpacity,
-          map: self._map,
-          clickable: false
-        });
-        self._map.setOptions({ gestureHandling: "none" });
+      } else if (self.mode === "rectangle") {
+        if (self.rectState === null) {
+          // First click: anchor the first corner and show a preview rectangle
+          self.rectState = "started";
+          self.startLatLng = e.latLng;
+          self.previewRect = new google.maps.Rectangle({
+            bounds: new google.maps.LatLngBounds(e.latLng, e.latLng),
+            strokeColor: RECTANGLE_STYLE.strokeColor,
+            strokeOpacity: RECTANGLE_STYLE.strokeOpacity,
+            strokeWeight: RECTANGLE_STYLE.strokeWeight,
+            fillColor: RECTANGLE_STYLE.fillColor,
+            fillOpacity: RECTANGLE_STYLE.fillOpacity,
+            map: self._map,
+            clickable: false
+          });
+        } else {
+          // Second click: finalize bounds (normalise so any corner order works)
+          self.rectState = null;
+          var sw = new google.maps.LatLng(
+            Math.min(self.startLatLng.lat(), e.latLng.lat()),
+            Math.min(self.startLatLng.lng(), e.latLng.lng())
+          );
+          var ne = new google.maps.LatLng(
+            Math.max(self.startLatLng.lat(), e.latLng.lat()),
+            Math.max(self.startLatLng.lng(), e.latLng.lng())
+          );
+          var rect = self.previewRect;
+          rect.setBounds(new google.maps.LatLngBounds(sw, ne));
+          self.previewRect = null;
+          self.startLatLng = null;
+          self._emit("rectanglecomplete", rect);
+        }
       }
     });
 
     this._map.addListener("mousemove", function (e) {
-      if (self.isDrawing && self.previewRect) {
-        self.previewRect.setBounds(
-          new google.maps.LatLngBounds(self.startLatLng, e.latLng)
+      if (self.rectState === "started" && self.previewRect) {
+        var sw = new google.maps.LatLng(
+          Math.min(self.startLatLng.lat(), e.latLng.lat()),
+          Math.min(self.startLatLng.lng(), e.latLng.lng())
         );
-      }
-    });
-
-    this._map.addListener("mouseup", function () {
-      if (self.isDrawing && self.previewRect) {
-        self.isDrawing = false;
-        self._map.setOptions({ gestureHandling: "auto" });
-        var rect = self.previewRect;
-        self.previewRect = null;
-        self._emit("rectanglecomplete", rect);
+        var ne = new google.maps.LatLng(
+          Math.max(self.startLatLng.lat(), e.latLng.lat()),
+          Math.max(self.startLatLng.lng(), e.latLng.lng())
+        );
+        self.previewRect.setBounds(new google.maps.LatLngBounds(sw, ne));
       }
     });
   };
@@ -502,7 +536,8 @@ $(document).ready(function () {
         strokeWeight: RECTANGLE_STYLE.strokeWeight,
         fillColor: RECTANGLE_STYLE.fillColor,
         fillOpacity: RECTANGLE_STYLE.fillOpacity,
-        map: map
+        map: map,
+        clickable: false
       });
 
       var label = createLabeledMarker(bounds.getCenter(), displayNumber.toString());
@@ -520,7 +555,7 @@ $(document).ready(function () {
       drawnOverlays.push({ rowId: currentRowId, overlay: marker });
     }
 
-    fitMapBounds();
+    fitMapBoundsForRow(currentRowId);
   }
 
   /**
@@ -539,6 +574,39 @@ $(document).ready(function () {
       }
       return true;
     });
+  }
+
+  /**
+   * Adjusts the map's viewport to fit the drawn overlays for a single row.
+   *
+   * @param {string} rowId - The row whose overlays define the viewport.
+   */
+  function fitMapBoundsForRow(rowId) {
+    var bounds = new google.maps.LatLngBounds();
+    drawnOverlays.forEach(function (item) {
+      if (item.rowId !== rowId) return;
+      if (item.overlay.getBounds) {
+        bounds.union(item.overlay.getBounds());
+      } else if (item.overlay.position) {
+        var pos = item.overlay.position;
+        if (typeof pos.lat === "function") {
+          bounds.extend(pos);
+        } else {
+          bounds.extend(new google.maps.LatLng(pos.lat, pos.lng));
+        }
+      } else if (item.overlay.getPosition) {
+        bounds.extend(item.overlay.getPosition());
+      }
+    });
+    if (!bounds.isEmpty()) {
+      var ne = bounds.getNorthEast();
+      var sw = bounds.getSouthWest();
+      var lat_buffer = (ne.lat() - sw.lat()) * 0.5 || 2;
+      var lng_buffer = (ne.lng() - sw.lng()) * 0.5 || 2;
+      bounds.extend(new google.maps.LatLng(ne.lat() + lat_buffer, ne.lng() + lng_buffer));
+      bounds.extend(new google.maps.LatLng(sw.lat() - lat_buffer, sw.lng() - lng_buffer));
+      map.fitBounds(bounds);
+    }
   }
 
   /**
@@ -652,6 +720,7 @@ $(document).ready(function () {
   // Make functions globally accessible
   window.deleteDrawnOverlaysForRow = deleteDrawnOverlaysForRow;
   window.fitMapBounds = fitMapBounds;
+  window.fitMapBoundsForRow = fitMapBoundsForRow;
   window.updateOverlayLabels = updateOverlayLabels;
   window.updateMapOverlay = updateMapOverlay;
 });

--- a/js/map.js
+++ b/js/map.js
@@ -105,6 +105,8 @@ $(document).ready(function () {
     this.startLatLng = null;
     /** @type {?google.maps.Rectangle} Temporary preview rectangle during drag */
     this.previewRect = null;
+    /** @type {?number} Pending single-click debounce timer (on instance so setMode can cancel it) */
+    this._clickTimer = null;
     /** @type {Object} Registered event callbacks */
     this._listeners = { rectanglecomplete: [], markercomplete: [] };
     /** @type {google.maps.Map} */
@@ -145,6 +147,19 @@ $(document).ready(function () {
    * @param {string} mode - The drawing mode to activate ('marker' or 'rectangle').
    */
   DrawingController.prototype.setMode = function (mode) {
+    // Cancel any click that hasn't fired yet so it can't bleed into the new mode
+    if (this._clickTimer !== null) {
+      clearTimeout(this._clickTimer);
+      this._clickTimer = null;
+    }
+    // Discard any in-progress rectangle so the new mode always starts clean
+    if (this.previewRect) {
+      this.previewRect.setMap(null);
+      this.previewRect = null;
+    }
+    this.rectState = null;
+    this.startLatLng = null;
+
     this.mode = mode;
     this._updateToolbarUI();
     this._map.setOptions({
@@ -177,23 +192,21 @@ $(document).ready(function () {
    */
   DrawingController.prototype._setupMapListeners = function () {
     var self = this;
-    /** @type {?number} Pending single-click timer handle */
-    var clickTimer = null;
     /** @type {number} Two clicks within this window (ms) are treated as a double-click */
     var DBLCLICK_THRESHOLD = 150;
 
     this._map.addListener("click", function (e) {
-      if (clickTimer !== null) {
+      if (self._clickTimer !== null) {
         // Second click arrived within the threshold – treat as double-click.
         // Cancel the pending drawing action; Google Maps handles the zoom via dblclick.
-        clearTimeout(clickTimer);
-        clickTimer = null;
+        clearTimeout(self._clickTimer);
+        self._clickTimer = null;
         return;
       }
 
       var latLng = e.latLng;
-      clickTimer = setTimeout(function () {
-        clickTimer = null;
+      self._clickTimer = setTimeout(function () {
+        self._clickTimer = null;
         if (self.mode === "marker") {
           var marker = new AdvancedMarkerElement({
             position: latLng,

--- a/js/map.js
+++ b/js/map.js
@@ -177,47 +177,63 @@ $(document).ready(function () {
    */
   DrawingController.prototype._setupMapListeners = function () {
     var self = this;
+    /** @type {?number} Pending single-click timer handle */
+    var clickTimer = null;
+    /** @type {number} Two clicks within this window (ms) are treated as a double-click */
+    var DBLCLICK_THRESHOLD = 150;
 
     this._map.addListener("click", function (e) {
-      if (self.mode === "marker") {
-        var marker = new AdvancedMarkerElement({
-          position: e.latLng,
-          map: self._map
-        });
-        self._emit("markercomplete", marker);
-      } else if (self.mode === "rectangle") {
-        if (self.rectState === null) {
-          // First click: anchor the first corner and show a preview rectangle
-          self.rectState = "started";
-          self.startLatLng = e.latLng;
-          self.previewRect = new google.maps.Rectangle({
-            bounds: new google.maps.LatLngBounds(e.latLng, e.latLng),
-            strokeColor: RECTANGLE_STYLE.strokeColor,
-            strokeOpacity: RECTANGLE_STYLE.strokeOpacity,
-            strokeWeight: RECTANGLE_STYLE.strokeWeight,
-            fillColor: RECTANGLE_STYLE.fillColor,
-            fillOpacity: RECTANGLE_STYLE.fillOpacity,
-            map: self._map,
-            clickable: false
-          });
-        } else {
-          // Second click: finalize bounds (normalise so any corner order works)
-          self.rectState = null;
-          var sw = new google.maps.LatLng(
-            Math.min(self.startLatLng.lat(), e.latLng.lat()),
-            Math.min(self.startLatLng.lng(), e.latLng.lng())
-          );
-          var ne = new google.maps.LatLng(
-            Math.max(self.startLatLng.lat(), e.latLng.lat()),
-            Math.max(self.startLatLng.lng(), e.latLng.lng())
-          );
-          var rect = self.previewRect;
-          rect.setBounds(new google.maps.LatLngBounds(sw, ne));
-          self.previewRect = null;
-          self.startLatLng = null;
-          self._emit("rectanglecomplete", rect);
-        }
+      if (clickTimer !== null) {
+        // Second click arrived within the threshold – treat as double-click.
+        // Cancel the pending drawing action; Google Maps handles the zoom via dblclick.
+        clearTimeout(clickTimer);
+        clickTimer = null;
+        return;
       }
+
+      var latLng = e.latLng;
+      clickTimer = setTimeout(function () {
+        clickTimer = null;
+        if (self.mode === "marker") {
+          var marker = new AdvancedMarkerElement({
+            position: latLng,
+            map: self._map
+          });
+          self._emit("markercomplete", marker);
+        } else if (self.mode === "rectangle") {
+          if (self.rectState === null) {
+            // First click: anchor the first corner and show a preview rectangle
+            self.rectState = "started";
+            self.startLatLng = latLng;
+            self.previewRect = new google.maps.Rectangle({
+              bounds: new google.maps.LatLngBounds(latLng, latLng),
+              strokeColor: RECTANGLE_STYLE.strokeColor,
+              strokeOpacity: RECTANGLE_STYLE.strokeOpacity,
+              strokeWeight: RECTANGLE_STYLE.strokeWeight,
+              fillColor: RECTANGLE_STYLE.fillColor,
+              fillOpacity: RECTANGLE_STYLE.fillOpacity,
+              map: self._map,
+              clickable: false
+            });
+          } else {
+            // Second click: finalize bounds (normalise so any corner order works)
+            self.rectState = null;
+            var sw = new google.maps.LatLng(
+              Math.min(self.startLatLng.lat(), latLng.lat()),
+              Math.min(self.startLatLng.lng(), latLng.lng())
+            );
+            var ne = new google.maps.LatLng(
+              Math.max(self.startLatLng.lat(), latLng.lat()),
+              Math.max(self.startLatLng.lng(), latLng.lng())
+            );
+            var rect = self.previewRect;
+            rect.setBounds(new google.maps.LatLngBounds(sw, ne));
+            self.previewRect = null;
+            self.startLatLng = null;
+            self._emit("rectanglecomplete", rect);
+          }
+        }
+      }, DBLCLICK_THRESHOLD);
     });
 
     this._map.addListener("mousemove", function (e) {
@@ -347,6 +363,22 @@ $(document).ready(function () {
       mapOptions.mapId = mapId;
     }
     map = new Map(mapElement, mapOptions);
+
+    // Keyboard zoom: + / = zooms in, - zooms out, active whenever the map modal is visible.
+    document.addEventListener("keydown", function (e) {
+      var modal = document.getElementById("modal-stc-map");
+      if (!modal || !modal.classList.contains("show")) return;
+      // Don't steal keystrokes from text inputs (e.g. the place-search field)
+      var tag = e.target ? e.target.tagName.toUpperCase() : "";
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (e.key === "+" || e.key === "=") {
+        e.preventDefault();
+        map.setZoom(map.getZoom() + 1);
+      } else if (e.key === "-") {
+        e.preventDefault();
+        map.setZoom(map.getZoom() - 1);
+      }
+    });
 
     // Setup custom drawing controller (replaces deprecated DrawingManager)
     var drawingController = new DrawingController(map);

--- a/tests/js/map.test.js
+++ b/tests/js/map.test.js
@@ -261,4 +261,94 @@ describe('map.js', () => {
     expect(calls).toContain('marker');
     expect(calls).toContain('places');
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DrawingController: mode switching and preview rectangle
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('DrawingController: mode switching and preview rectangle', () => {
+    // Safely above the 150 ms DBLCLICK_THRESHOLD in map.js
+    const OVER_THRESHOLD = 250;
+
+    function fireMapEvent(eventName, lat, lng) {
+      (mapInstance.listeners[eventName] || []).forEach(cb =>
+        cb({ latLng: new google.maps.LatLng(lat, lng) })
+      );
+    }
+
+    function waitMs(ms) {
+      return new Promise(r => setTimeout(r, ms));
+    }
+
+    beforeEach(() => {
+      // Wire up #modal-stc-map so the rectanglecomplete / markercomplete handlers
+      // can find the current row and write coordinate values into its inputs.
+      const row1El = document.querySelector('[tsc-row-id="row1"]');
+      document.getElementById('modal-stc-map')._data = {
+        'current-row': global.$(row1El),
+        'tsc-row-id': 'row1'
+      };
+    });
+
+    test('preview rect appears and follows mouse: place marker → switch to rect → click first corner', async () => {
+      // 1. Place a marker in the default marker mode
+      fireMapEvent('click', 52.5, 13.4);
+      await waitMs(OVER_THRESHOLD);
+      expect(createdMarkers.length).toBeGreaterThan(0);
+
+      // 2. Switch to rectangle mode
+      document.getElementById('btn-draw-rectangle').click();
+
+      // 3. Click the first corner of the rectangle
+      fireMapEvent('click', 52.6, 13.5);
+      await waitMs(OVER_THRESHOLD);
+
+      // A preview rectangle must have been created and remain on the map
+      expect(createdRectangles.length).toBe(1);
+      expect(createdRectangles[0].map).not.toBeNull();
+
+      // Coordinate inputs must still be empty — rectangle is not yet completed
+      expect(document.querySelector('[id^=input-stc-latmax]').value).toBe('');
+
+      // Moving the mouse must update the preview bounds
+      fireMapEvent('mousemove', 52.7, 13.6);
+      expect(createdRectangles[0].setBounds).toHaveBeenCalled();
+    });
+
+    test('switching modes mid-rectangle resets state so the next first click starts a fresh preview', async () => {
+      // Start a rectangle — click first corner and wait for debounce
+      document.getElementById('btn-draw-rectangle').click();
+      fireMapEvent('click', 52.6, 13.5);
+      await waitMs(OVER_THRESHOLD); // rectState = 'started', previewRect on map
+
+      expect(createdRectangles.length).toBe(1);
+
+      // Switch away and back (user hesitation / back-and-forth)
+      document.getElementById('btn-draw-marker').click();
+      document.getElementById('btn-draw-rectangle').click();
+
+      // User now clicks what they intend as the FIRST corner of a new rectangle
+      fireMapEvent('click', 52.8, 13.6);
+      await waitMs(OVER_THRESHOLD);
+
+      // BUG (unfixed): stale rectState='started' causes this click to be treated as
+      // the second click → rectanglecomplete fires immediately → inputs get filled.
+      // FIXED: setMode resets state, so this click only starts the preview.
+      expect(document.querySelector('[id^=input-stc-latmax]').value).toBe('');
+    });
+
+    test('clicking in rect mode then quickly switching to marker cancels the pending rectangle click', async () => {
+      document.getElementById('btn-draw-rectangle').click();
+
+      // Click in rectangle mode, then switch modes BEFORE the debounce fires
+      fireMapEvent('click', 52.6, 13.5);
+      document.getElementById('btn-draw-marker').click(); // switch within 150 ms
+
+      await waitMs(OVER_THRESHOLD);
+
+      // BUG (unfixed): the debounce timer fires in marker mode and creates an
+      // unintended marker at the rectangle click coordinates.
+      // FIXED: setMode cancels the pending timer, so no marker appears.
+      expect(createdMarkers.length).toBe(0);
+    });
+  });
 });

--- a/tests/js/map.test.js
+++ b/tests/js/map.test.js
@@ -350,5 +350,46 @@ describe('map.js', () => {
       // FIXED: setMode cancels the pending timer, so no marker appears.
       expect(createdMarkers.length).toBe(0);
     });
+
+    test('right-click after first rectangle corner removes the preview and resets to initial state', async () => {
+      document.getElementById('btn-draw-rectangle').click();
+
+      // Place the first corner
+      fireMapEvent('click', 52.6, 13.5);
+      await waitMs(OVER_THRESHOLD); // previewRect created, rectState = 'started'
+
+      expect(createdRectangles.length).toBe(1);
+      expect(createdRectangles[0].map).not.toBeNull();
+
+      // Right-click: cancel the in-progress rectangle
+      fireMapEvent('rightclick', 0, 0);
+
+      // Preview rect must have been removed from the map
+      expect(createdRectangles[0].setMap).toHaveBeenCalledWith(null);
+
+      // A subsequent left-click must start a NEW first corner, not complete a rectangle
+      fireMapEvent('click', 52.9, 14.0);
+      await waitMs(OVER_THRESHOLD);
+
+      // Inputs still empty – the click started a fresh preview, not a completion
+      expect(document.querySelector('[id^=input-stc-latmax]').value).toBe('');
+      // A new preview rectangle must have been created
+      expect(createdRectangles.length).toBe(2);
+      expect(createdRectangles[1].map).not.toBeNull();
+    });
+
+    test('right-click while debounce is still pending (before first corner is anchored) is also a no-op', async () => {
+      document.getElementById('btn-draw-rectangle').click();
+
+      // Click, but right-click BEFORE the 150 ms debounce fires
+      fireMapEvent('click', 52.6, 13.5);
+      fireMapEvent('rightclick', 0, 0); // cancel during the pending timer
+
+      await waitMs(OVER_THRESHOLD);
+
+      // The pending click must have been swallowed — no preview rect, no coords
+      expect(createdRectangles.length).toBe(0);
+      expect(document.querySelector('[id^=input-stc-latmax]').value).toBe('');
+    });
   });
 });

--- a/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
+++ b/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
@@ -129,15 +129,34 @@ const googleMapsStub = String.raw`(() => {
     constructor(opts = {}) {
       this._bounds = opts.bounds || null;
       this._map = opts.map || null;
+      this._listeners = {};
     }
     setMap(map) {
       this._map = map;
     }
     setBounds(bounds) {
       this._bounds = bounds;
+      // Trigger bounds_changed event when bounds are set
+      this._triggerEvent('bounds_changed');
     }
     getBounds() {
       return this._bounds;
+    }
+    addListener(eventName, callback) {
+      if (!this._listeners[eventName]) {
+        this._listeners[eventName] = [];
+      }
+      this._listeners[eventName].push(callback);
+      return {
+        remove: () => {
+          this._listeners[eventName] = this._listeners[eventName].filter(cb => cb !== callback);
+        }
+      };
+    }
+    _triggerEvent(eventName) {
+      if (this._listeners[eventName]) {
+        this._listeners[eventName].forEach(cb => cb());
+      }
     }
   }
 
@@ -327,22 +346,38 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     // Switch to rectangle mode by clicking the rectangle toolbar button
     await page.locator('#btn-draw-rectangle').click();
 
-    // Simulate rectangle drawing: click (start) → mousemove (drag) → mouseup (complete)
+    // Simulate rectangle drawing by creating and setting bounds on a rectangle
     await page.evaluate(() => {
       const mapInstance = (window as any).__elmoMapInstance;
       const LatLng = (window as any).google.maps.LatLng;
+      const LatLngBounds = (window as any).google.maps.LatLngBounds;
+      const Rectangle = (window as any).google.maps.Rectangle;
 
-      // Start: click sets startLatLng and creates preview rectangle
-      (window as any).google.maps.event.trigger(mapInstance, 'click', {
-        latLng: new LatLng(40.0, -74.5),
+      // Create a rectangle with the target bounds
+      const rectangle = new Rectangle({
+        map: mapInstance,
+        bounds: new LatLngBounds(
+          new LatLng(40.0, -74.5),  // SW (min lat, min lng)
+          new LatLng(41.0, -73.5)   // NE (max lat, max lng)
+        )
       });
-      // Drag: mousemove updates preview rectangle bounds
-      (window as any).google.maps.event.trigger(mapInstance, 'mousemove', {
-        latLng: new LatLng(41.0, -73.5),
-      });
-      // Release: mouseup completes the rectangle
-      (window as any).google.maps.event.trigger(mapInstance, 'mouseup', {});
+
+      // Trigger bounds_changed event by calling setBounds
+      rectangle.setBounds(rectangle.getBounds());
+      
+      // Store reference for test to verify
+      (window as any).__testRectangle = rectangle;
     });
+
+    // Wait for coordinate fields to be populated
+    await page.waitForFunction(
+      () => {
+        const latMax = document.querySelector('#input-stc-latmax_1') as HTMLInputElement;
+        const longMax = document.querySelector('#input-stc-longmax_1') as HTMLInputElement;
+        return latMax?.value && longMax?.value;
+      },
+      { timeout: 5000 }
+    );
 
     await expect(latMax).toHaveValue(/41(?:\.0+)?/);
     await expect(longMax).toHaveValue(/-73\.5/);

--- a/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
+++ b/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
@@ -346,38 +346,27 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     // Switch to rectangle mode by clicking the rectangle toolbar button
     await page.locator('#btn-draw-rectangle').click();
 
-    // Simulate rectangle drawing by creating and setting bounds on a rectangle
+    // Rectangle drawing uses TWO clicks (not click+drag): first click anchors the
+    // first corner, second click completes it. A 150ms double-click guard timer
+    // must expire between clicks, so we wait 300ms after each.
+
+    // First click – anchors first corner, starts the preview rectangle
     await page.evaluate(() => {
       const mapInstance = (window as any).__elmoMapInstance;
-      const LatLng = (window as any).google.maps.LatLng;
-      const LatLngBounds = (window as any).google.maps.LatLngBounds;
-      const Rectangle = (window as any).google.maps.Rectangle;
-
-      // Create a rectangle with the target bounds
-      const rectangle = new Rectangle({
-        map: mapInstance,
-        bounds: new LatLngBounds(
-          new LatLng(40.0, -74.5),  // SW (min lat, min lng)
-          new LatLng(41.0, -73.5)   // NE (max lat, max lng)
-        )
+      (window as any).google.maps.event.trigger(mapInstance, 'click', {
+        latLng: new (window as any).google.maps.LatLng(40.0, -74.5),
       });
-
-      // Trigger bounds_changed event by calling setBounds
-      rectangle.setBounds(rectangle.getBounds());
-      
-      // Store reference for test to verify
-      (window as any).__testRectangle = rectangle;
     });
+    await page.waitForTimeout(300); // wait for 150ms DBLCLICK_THRESHOLD timer to fire
 
-    // Wait for coordinate fields to be populated
-    await page.waitForFunction(
-      () => {
-        const latMax = document.querySelector('#input-stc-latmax_1') as HTMLInputElement;
-        const longMax = document.querySelector('#input-stc-longmax_1') as HTMLInputElement;
-        return latMax?.value && longMax?.value;
-      },
-      { timeout: 5000 }
-    );
+    // Second click – completes the rectangle and emits 'rectanglecomplete'
+    await page.evaluate(() => {
+      const mapInstance = (window as any).__elmoMapInstance;
+      (window as any).google.maps.event.trigger(mapInstance, 'click', {
+        latLng: new (window as any).google.maps.LatLng(41.0, -73.5),
+      });
+    });
+    await page.waitForTimeout(300); // wait for timer to fire and fields to update
 
     await expect(latMax).toHaveValue(/41(?:\.0+)?/);
     await expect(longMax).toHaveValue(/-73\.5/);

--- a/tests/playwright/formgroups/thesauri-keywords-roundtrip.spec.ts
+++ b/tests/playwright/formgroups/thesauri-keywords-roundtrip.spec.ts
@@ -88,6 +88,30 @@ async function waitForThesauriInit(page: import('@playwright/test').Page) {
   await page.waitForFunction(() => Boolean((document.querySelector('#input-sciencekeyword') as any)?._tagify), { timeout: 15000 });
 }
 
+async function triggerTranslationsAndWaitForThesauri(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const header = document.querySelector('[data-translate="keywords.thesaurus.name"]');
+    if (header) header.textContent = 'Thesauri Keywords';
+  });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.evaluate(() => {
+      document.dispatchEvent(new Event('translationsLoaded'));
+    });
+
+    try {
+      await page.waitForFunction(() => {
+        const accordion = document.getElementById('accordionThesauri');
+        return accordion && accordion.children.length > 0;
+      }, { timeout: 5000 });
+      await page.waitForFunction(() => Boolean((document.querySelector('#input-sciencekeyword') as any)?._tagify), { timeout: 5000 });
+      return;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+}
+
 test.describe('Thesaurus Keywords Roundtrip (Issue #1043)', () => {
   test.beforeEach(async ({ page }) => {
     await page.route(`**${TEST_ROUTE_PATH}`, async route => {
@@ -141,13 +165,7 @@ test.describe('Thesaurus Keywords Roundtrip (Issue #1043)', () => {
 
     await injectModuleScript(page, 'js/thesauri.js');
 
-    await page.evaluate(() => {
-      const header = document.querySelector('[data-translate="keywords.thesaurus.name"]');
-      if (header) header.textContent = 'Thesauri Keywords';
-      document.dispatchEvent(new Event('translationsLoaded'));
-    });
-
-    await waitForThesauriInit(page);
+    await triggerTranslationsAndWaitForThesauri(page);
   });
 
   test('processKeywords loads tags with all metadata fields including language', async ({ page }) => {

--- a/tests/playwright/formgroups/thesauri-keywords-roundtrip.spec.ts
+++ b/tests/playwright/formgroups/thesauri-keywords-roundtrip.spec.ts
@@ -101,8 +101,8 @@ async function triggerTranslationsAndWaitForThesauri(page: import('@playwright/t
 
     try {
       await page.waitForFunction(() => {
-        const accordion = document.getElementById('accordionThesauri');
-        return accordion && accordion.children.length > 0;
+        const thesaurusGroup = document.getElementById('thesaurusKeywordsGroup');
+        return thesaurusGroup && thesaurusGroup.children.length > 0;
       }, { timeout: 5000 });
       await page.waitForFunction(() => Boolean((document.querySelector('#input-sciencekeyword') as any)?._tagify), { timeout: 5000 });
       return;


### PR DESCRIPTION
Map on prod is functionall but raher hard to use because normal 

## Changes
### Click Handling ([map.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Two-click rectangle drawing (replaced deprecated DrawingManager)
A custom [DrawingController](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) class implements rectangle drawing as a two-click state machine: the first click anchors the starting corner ([rectState = "started"](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), a live mousemove listener updates a transparent preview rectangle, and the second click finalises the bounds. Corner order is normalised with [Math.min/max](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so any two diagonal clicks produce a valid SW/NE bounding box.

Double-click debounce (150 ms)
A click is only actioned after a 150 ms timer. If a second click arrives within that window, both are cancelled — this prevents the two-click rectangle logic from interfering with Google Maps' native double-click zoom.

Right-click to cancel in-progress rectangle
A rightclick listener on the map checks whether a first corner has already been placed ([rectState === "started"](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) and, if so: cancels any pending debounce timer, removes the preview rectangle from the map, and resets [rectState](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [startLatLng](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to null. This also handles the edge case where right-click arrives within the 150 ms debounce window (the pending timer is cleared unconditionally).

Keyboard zoom
A keydown listener is active whenever the map modal is visible. +/= zooms in, - zooms out. Input fields, textareas and selects are excluded so typing is never intercepted.

Mode-switching cleanup
[DrawingController.prototype.setMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) cancels any pending debounce timer ([this._clickTimer](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), removes and nulls the preview rectangle, and resets all rectangle state before applying the new mode. This prevents a stale timer from firing in the wrong mode after a rapid switch.

### Multiple STC Entries ([map.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Each spatial/temporal coverage row has its own [rowId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). All drawn overlays are stored as [{ rowId, overlay, labelOverlay }](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in a shared [drawnOverlays](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) array.

[fitMapBoundsForRow(rowId)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — fits the map viewport only to the overlays belonging to the currently opened row, with a 50 % padding buffer (minimum 2°). Called on modal open and after a coordinate is placed.
[updateMapOverlay()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — calls [fitMapBoundsForRow(currentRowId)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) rather than a global fit, so opening a row's map never shifts the view to another row's coordinates.
Modal open logic — reads the row's coordinate inputs: if coordinates are present it ensures the overlay exists (creates it if needed) and calls [fitMapBoundsForRow](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html); if the row has no coordinates yet it resets to a whole-planet view ([zoom: 2, centre: {lat:20, lng:0}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
[deleteDrawnOverlaysForRow(rowId)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removes only the overlays for the cancelled/cleared row, leaving other rows' overlays intact.

### In-context Help
Map modal ([coverage.html](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Added a [<i class="bi bi-question-circle-fill" data-help-section-id="help-stc-fg-map">](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) icon in the modal header alongside the title, giving users direct access to the map instructions without leaving the modal.

### Test Coverage ([map.test.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
16 Jest unit tests, all passing. The [DrawingController](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) suite covers:

- Preview rectangle lifecycle (appears on first click, follows mouse, completes on second click)
- Mode-switching mid-rectangle resets state
- Rapid mode-switch cancels pending debounce timer (no ghost marker)
- Right-click after first corner removes preview and allows a fresh start
- Right-click during pending debounce swallows the pending click cleanly

## Notes for Reviewer
The place search is impossible to test locally.

Please make sure that the coordinates from the map modal are transmitted into the form group and vice versa

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
None
