### PR TITLE
Feature: researcher submission confirmation emails

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,6 +23,7 @@
                             <li>ELMOGEM version can save the documents according to the ICGEM metadata schema</li>
                             <li>ELMOGEM version: the documents according to the ICGEM metadata schema can be uploaded into the editor</li>
                             <li>Removed the Thesauri accordions and the connector lines in the keyword tree</li>
+                            <li>Confirmation emails for researchers after successful metadata submission</li>
 
 
                         </ul>

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -158,12 +158,19 @@ function createAndAttachXmlFile(PHPMailer $mail, string $xml_content, int $resou
 }
 
 
+/**
+ * Extract title and unique researcher contacts from XML.
+ *
+ * @param string $xml_content Raw XML content.
+ * @return array{title: string, contacts: array<int, array{fullName: string, email: string}>}
+ */
 function collectResearcherConfirmationDataFromXml(string $xml_content): array
 {
     $title = '';
     $contacts = [];
     $seen = [];
 
+    // Stop early if XML is empty.
     if (empty(trim($xml_content))) {
         error_log("Researcher confirmation: XML content is empty.");
         return [
@@ -173,13 +180,16 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
     }
 
     try {
+        // Parse XML content.
         $xml = new SimpleXMLElement($xml_content);
 
+        // Read dataset title.
         $titleNodes = $xml->xpath('//*[local-name()="title"]');
         if ($titleNodes !== false && !empty($titleNodes)) {
             $title = trim((string) $titleNodes[0]);
         }
 
+        // Read all point of contact entries.
         $pointOfContactNodes = $xml->xpath('//*[local-name()="pointOfContact"]');
 
         error_log("Researcher confirmation: XML title = " . ($title !== '' ? $title : '[empty]'));
@@ -193,18 +203,22 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
                 $fullName = '';
                 $email = '';
 
+                // Extract raw name.
                 if ($nameNodes !== false && !empty($nameNodes)) {
                     $fullName = trim((string) $nameNodes[0]);
                 }
 
+                // Extract raw email.
                 if ($emailNodes !== false && !empty($emailNodes)) {
                     $email = trim((string) $emailNodes[0]);
                 }
 
+                // Fallback name.
                 if ($fullName === '') {
                     $fullName = 'researcher';
                 }
 
+                // Convert "Last, First" to "First Last".
                 if (strpos($fullName, ',') !== false) {
                     $nameParts = array_map('trim', explode(',', $fullName, 2));
                     $familyName = $nameParts[0] ?? '';
@@ -212,10 +226,12 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
                     $fullName = trim($givenName . ' ' . $familyName);
                 }
 
+                // Skip invalid email addresses.
                 if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
                     continue;
                 }
 
+                // Skip duplicate contacts.
                 $key = mb_strtolower($fullName) . '|' . mb_strtolower($email);
                 if (isset($seen[$key])) {
                     continue;
@@ -233,6 +249,7 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
 
         error_log("Researcher confirmation: XML prepared contact count = " . count($contacts));
     } catch (Exception $e) {
+        // Log XML parsing errors.
         error_log("Researcher confirmation: Failed to parse XML. " . $e->getMessage());
     }
 

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -157,6 +157,91 @@ function createAndAttachXmlFile(PHPMailer $mail, string $xml_content, int $resou
     return $xmlFilename;
 }
 
+
+function collectResearcherConfirmationDataFromXml(string $xml_content): array
+{
+    $title = '';
+    $contacts = [];
+    $seen = [];
+
+    if (empty(trim($xml_content))) {
+        error_log("Researcher confirmation: XML content is empty.");
+        return [
+            'title' => $title,
+            'contacts' => $contacts,
+        ];
+    }
+
+    try {
+        $xml = new SimpleXMLElement($xml_content);
+
+        $titleNodes = $xml->xpath('//*[local-name()="title"]');
+        if ($titleNodes !== false && !empty($titleNodes)) {
+            $title = trim((string) $titleNodes[0]);
+        }
+
+        $pointOfContactNodes = $xml->xpath('//*[local-name()="pointOfContact"]');
+
+        error_log("Researcher confirmation: XML title = " . ($title !== '' ? $title : '[empty]'));
+        error_log("Researcher confirmation: XML raw pointOfContact count = " . (is_array($pointOfContactNodes) ? count($pointOfContactNodes) : 0));
+
+        if ($pointOfContactNodes !== false) {
+            foreach ($pointOfContactNodes as $pointOfContactNode) {
+                $nameNodes = $pointOfContactNode->xpath('.//*[local-name()="individualName"]//*[local-name()="CharacterString"]');
+                $emailNodes = $pointOfContactNode->xpath('.//*[local-name()="electronicMailAddress"]//*[local-name()="CharacterString"]');
+
+                $fullName = '';
+                $email = '';
+
+                if ($nameNodes !== false && !empty($nameNodes)) {
+                    $fullName = trim((string) $nameNodes[0]);
+                }
+
+                if ($emailNodes !== false && !empty($emailNodes)) {
+                    $email = trim((string) $emailNodes[0]);
+                }
+
+                if ($fullName === '') {
+                    $fullName = 'researcher';
+                }
+
+                if (strpos($fullName, ',') !== false) {
+                    $nameParts = array_map('trim', explode(',', $fullName, 2));
+                    $familyName = $nameParts[0] ?? '';
+                    $givenName = $nameParts[1] ?? '';
+                    $fullName = trim($givenName . ' ' . $familyName);
+                }
+
+                if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    continue;
+                }
+
+                $key = mb_strtolower($fullName) . '|' . mb_strtolower($email);
+                if (isset($seen[$key])) {
+                    continue;
+                }
+
+                $seen[$key] = true;
+                $contacts[] = [
+                    'fullName' => $fullName,
+                    'email' => $email,
+                ];
+
+                error_log("Researcher confirmation: XML contact {$fullName} <{$email}>");
+            }
+        }
+
+        error_log("Researcher confirmation: XML prepared contact count = " . count($contacts));
+    } catch (Exception $e) {
+        error_log("Researcher confirmation: Failed to parse XML. " . $e->getMessage());
+    }
+
+    return [
+        'title' => $title,
+        'contacts' => $contacts,
+    ];
+}
+
 $resource_id = false; // Initialize to false (matches saveResourceInformationAndRights return type)
 
 try {
@@ -371,6 +456,7 @@ if (!$simulateEmail) {
 } else {
     error_log("Warning: the email was not sent! You are strongly assuming you are in development right now! SIMULATE_EMAIL was set true - skipping SMTP and PHPMailer.");
 }
+    $researcherConfirmationData = collectResearcherConfirmationDataFromXml($xml_content);
 
     error_log("send_xml_file.php: About to return success");
 

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -220,7 +220,7 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
                 // Convert "Last, First" to "First Last".
                 if (strpos($fullName, ',') !== false) {
                     $nameParts = array_map('trim', explode(',', $fullName, 2));
-                    $familyName = $nameParts[0] ?? '';
+                    $familyName = $nameParts[0];
                     $givenName = $nameParts[1] ?? '';
                     $fullName = trim($givenName . ' ' . $familyName);
                 }

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -192,9 +192,6 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
         // Read all point of contact entries.
         $pointOfContactNodes = $xml->xpath('//*[local-name()="pointOfContact"]');
 
-        error_log("Researcher confirmation: XML title = " . ($title !== '' ? $title : '[empty]'));
-        error_log("Researcher confirmation: XML raw pointOfContact count = " . (is_array($pointOfContactNodes) ? count($pointOfContactNodes) : 0));
-
         foreach ($pointOfContactNodes ?: [] as $pointOfContactNode) {
                 $nameNodes = $pointOfContactNode->xpath('.//*[local-name()="individualName"]//*[local-name()="CharacterString"]');
                 $emailNodes = $pointOfContactNode->xpath('.//*[local-name()="electronicMailAddress"]//*[local-name()="CharacterString"]');
@@ -241,11 +238,9 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
                     'fullName' => $fullName,
                     'email' => $email,
                 ];
-
-                error_log("Researcher confirmation: XML contact {$fullName} <{$email}>");
             }
 
-        error_log("Researcher confirmation: XML prepared contact count = " . count($contacts));
+        error_log('Researcher confirmation: Extracted ' . count($contacts) . ' contact(s) from XML.');
     } catch (Exception $e) {
         // Log XML parsing errors.
         error_log("Researcher confirmation: Failed to parse XML. " . $e->getMessage());
@@ -274,6 +269,8 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
         error_log('Researcher confirmation: No contacts found.');
         return;
     }
+
+    $processedCount = 0;
 
     foreach ($contacts as $contact) {
         $fullName = trim((string) ($contact['fullName'] ?? 'researcher'));
@@ -306,17 +303,8 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             "Best regards\n" .
             "ELMO";
 
-        // Log preview in simulation mode.
         if ($simulateEmail) {
-            $preview =
-                "To: {$fullName} <{$email}>\n" .
-                "Subject: {$subject}\n\n" .
-                $plainBody;
-
-            foreach (explode("\n", str_replace("\r", '', $preview)) as $line) {
-                error_log($line);
-            }
-
+            $processedCount++;
             continue;
         }
 
@@ -350,12 +338,14 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             $mail->AltBody = $plainBody;
             $mail->send();
 
-            error_log("Researcher confirmation: Email sent to {$fullName} <{$email}>.");
+            $processedCount++;
         } catch (Exception $e) {
             // Log send failure.
             error_log("Researcher confirmation: Failed to send email to {$fullName} <{$email}>. " . $e->getMessage());
         }
     }
+
+    error_log('Researcher confirmation: ' . ($simulateEmail ? 'Simulated' : 'Sent') . ' ' . $processedCount . ' confirmation email(s).');
 }
 $resource_id = false; // Initialize to false (matches saveResourceInformationAndRights return type)
 

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -325,10 +325,15 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             $mail = new PHPMailer(true);
 
             $mail->isSMTP();
+            // @phpstan-ignore constant.notFound
             $mail->Host = SMTP_HOST;
+            // @phpstan-ignore constant.notFound
             $mail->Port = SMTP_PORT;
+            // @phpstan-ignore constant.notFound
             $mail->SMTPAuth = SMTP_AUTH;
+            // @phpstan-ignore constant.notFound
             $mail->Username = SMTP_USERNAME;
+            // @phpstan-ignore constant.notFound
             $mail->Password = SMTP_PASSWORD;
 
             if (defined('SMTP_SECURE') && SMTP_SECURE) {
@@ -336,6 +341,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             }
 
             $mail->CharSet = 'UTF-8';
+            // @phpstan-ignore constant.notFound
             $mail->setFrom(MAIL_FROM_ADDRESS, 'ELMO');
             $mail->addAddress($email, $fullName);
             $mail->Subject = $subject;

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -242,6 +242,86 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
     ];
 }
 
+
+function sendResearcherConfirmationEmails(array $researcherConfirmationData, bool $simulateEmail = false): void
+{
+    $title = trim((string) ($researcherConfirmationData['title'] ?? ''));
+    $contacts = $researcherConfirmationData['contacts'] ?? [];
+
+    if (empty($contacts) || !is_array($contacts)) {
+        error_log('Researcher confirmation: No contacts found.');
+        return;
+    }
+
+    foreach ($contacts as $contact) {
+        $fullName = trim((string) ($contact['fullName'] ?? 'researcher'));
+        $email = trim((string) ($contact['email'] ?? ''));
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            error_log("Researcher confirmation: Invalid email for {$fullName}.");
+            continue;
+        }
+
+        $subject = 'Confirmation of your data submission to ELMO';
+
+        $htmlBody = '
+            <p>Dear ' . htmlspecialchars($fullName, ENT_QUOTES, 'UTF-8') . ',</p>
+            <p>Thank you for your data submission to ELMO.</p>
+            <p>Your data entry' . ($title !== '' ? ' titled "<strong>' . htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '</strong>"' : '') . ' has been received successfully.</p>
+            <p>The data curators will now review your submission. If further information is needed, they will contact you.</p>
+            <p>Best regards<br>ELMO</p>
+        ';
+
+        $plainBody =
+            "Dear {$fullName},\n\n" .
+            "Thank you for your data submission to ELMO.\n" .
+            "Your data entry" . ($title !== '' ? " titled \"{$title}\"" : '') . " has been received successfully.\n" .
+            "The data curators will now review your submission. If further information is needed, they will contact you.\n\n" .
+            "Best regards\n" .
+            "ELMO";
+
+        if ($simulateEmail) {
+            $preview =
+                "To: {$fullName} <{$email}>\n" .
+                "Subject: {$subject}\n\n" .
+                $plainBody;
+
+            foreach (explode("\n", str_replace("\r", '', $preview)) as $line) {
+                error_log($line);
+            }
+
+            continue;
+        }
+
+        try {
+            $mail = new PHPMailer(true);
+
+            $mail->isSMTP();
+            $mail->Host = SMTP_HOST;
+            $mail->Port = SMTP_PORT;
+            $mail->SMTPAuth = SMTP_AUTH;
+            $mail->Username = SMTP_USERNAME;
+            $mail->Password = SMTP_PASSWORD;
+
+            if (defined('SMTP_SECURE') && SMTP_SECURE) {
+                $mail->SMTPSecure = SMTP_SECURE;
+            }
+
+            $mail->CharSet = 'UTF-8';
+            $mail->setFrom(MAIL_FROM_ADDRESS, 'ELMO');
+            $mail->addAddress($email, $fullName);
+            $mail->Subject = $subject;
+            $mail->isHTML(true);
+            $mail->Body = $htmlBody;
+            $mail->AltBody = $plainBody;
+            $mail->send();
+
+            error_log("Researcher confirmation: Email sent to {$fullName} <{$email}>.");
+        } catch (Exception $e) {
+            error_log("Researcher confirmation: Failed to send email to {$fullName} <{$email}>. " . $e->getMessage());
+        }
+    }
+}
 $resource_id = false; // Initialize to false (matches saveResourceInformationAndRights return type)
 
 try {
@@ -457,6 +537,7 @@ if (!$simulateEmail) {
     error_log("Warning: the email was not sent! You are strongly assuming you are in development right now! SIMULATE_EMAIL was set true - skipping SMTP and PHPMailer.");
 }
     $researcherConfirmationData = collectResearcherConfirmationDataFromXml($xml_content);
+    sendResearcherConfirmationEmails($researcherConfirmationData, $simulateEmail);
 
     error_log("send_xml_file.php: About to return success");
 

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -260,11 +260,19 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
 }
 
 
+/**
+ * Send confirmation emails to all researcher contacts.
+ *
+ * @param array{title?: string, contacts?: array<int, array{fullName?: string, email?: string}>} $researcherConfirmationData Prepared title and contact data.
+ * @param bool $simulateEmail Log email preview instead of sending.
+ * @return void
+ */
 function sendResearcherConfirmationEmails(array $researcherConfirmationData, bool $simulateEmail = false): void
 {
     $title = trim((string) ($researcherConfirmationData['title'] ?? ''));
     $contacts = $researcherConfirmationData['contacts'] ?? [];
 
+    // Stop early if no contacts exist.
     if (empty($contacts) || !is_array($contacts)) {
         error_log('Researcher confirmation: No contacts found.');
         return;
@@ -274,13 +282,16 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
         $fullName = trim((string) ($contact['fullName'] ?? 'researcher'));
         $email = trim((string) ($contact['email'] ?? ''));
 
+        // Skip invalid email addresses.
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             error_log("Researcher confirmation: Invalid email for {$fullName}.");
             continue;
         }
 
+        // Static subject line.
         $subject = 'Confirmation of your data submission to ELMO';
 
+        // Build HTML email body.
         $htmlBody = '
             <p>Dear ' . htmlspecialchars($fullName, ENT_QUOTES, 'UTF-8') . ',</p>
             <p>Thank you for your data submission to ELMO.</p>
@@ -289,6 +300,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             <p>Best regards<br>ELMO</p>
         ';
 
+        // Build plain text fallback.
         $plainBody =
             "Dear {$fullName},\n\n" .
             "Thank you for your data submission to ELMO.\n" .
@@ -297,6 +309,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
             "Best regards\n" .
             "ELMO";
 
+        // Log preview in simulation mode.
         if ($simulateEmail) {
             $preview =
                 "To: {$fullName} <{$email}>\n" .
@@ -311,6 +324,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
         }
 
         try {
+            // Configure and send email.
             $mail = new PHPMailer(true);
 
             $mail->isSMTP();
@@ -335,6 +349,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
 
             error_log("Researcher confirmation: Email sent to {$fullName} <{$email}>.");
         } catch (Exception $e) {
+            // Log send failure.
             error_log("Researcher confirmation: Failed to send email to {$fullName} <{$email}>. " . $e->getMessage());
         }
     }

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -185,7 +185,7 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
 
         // Read dataset title.
         $titleNodes = $xml->xpath('//*[local-name()="title"]');
-        if ($titleNodes !== false && !empty($titleNodes)) {
+        if (!empty($titleNodes)) {
             $title = trim((string) $titleNodes[0]);
         }
 
@@ -195,8 +195,7 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
         error_log("Researcher confirmation: XML title = " . ($title !== '' ? $title : '[empty]'));
         error_log("Researcher confirmation: XML raw pointOfContact count = " . (is_array($pointOfContactNodes) ? count($pointOfContactNodes) : 0));
 
-        if ($pointOfContactNodes !== false) {
-            foreach ($pointOfContactNodes as $pointOfContactNode) {
+        foreach ($pointOfContactNodes ?: [] as $pointOfContactNode) {
                 $nameNodes = $pointOfContactNode->xpath('.//*[local-name()="individualName"]//*[local-name()="CharacterString"]');
                 $emailNodes = $pointOfContactNode->xpath('.//*[local-name()="electronicMailAddress"]//*[local-name()="CharacterString"]');
 
@@ -204,12 +203,12 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
                 $email = '';
 
                 // Extract raw name.
-                if ($nameNodes !== false && !empty($nameNodes)) {
+                if (!empty($nameNodes)) {
                     $fullName = trim((string) $nameNodes[0]);
                 }
 
                 // Extract raw email.
-                if ($emailNodes !== false && !empty($emailNodes)) {
+                if (!empty($emailNodes)) {
                     $email = trim((string) $emailNodes[0]);
                 }
 
@@ -245,7 +244,6 @@ function collectResearcherConfirmationDataFromXml(string $xml_content): array
 
                 error_log("Researcher confirmation: XML contact {$fullName} <{$email}>");
             }
-        }
 
         error_log("Researcher confirmation: XML prepared contact count = " . count($contacts));
     } catch (Exception $e) {

--- a/send_xml_file.php
+++ b/send_xml_file.php
@@ -270,8 +270,7 @@ function sendResearcherConfirmationEmails(array $researcherConfirmationData, boo
     $title = trim((string) ($researcherConfirmationData['title'] ?? ''));
     $contacts = $researcherConfirmationData['contacts'] ?? [];
 
-    // Stop early if no contacts exist.
-    if (empty($contacts) || !is_array($contacts)) {
+    if (empty($contacts)) {
         error_log('Researcher confirmation: No contacts found.');
         return;
     }

--- a/tests/ResearcherConfirmationTest.php
+++ b/tests/ResearcherConfirmationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+define('PHPUNIT_RUNNING', true);
+require_once __DIR__ . '/../send_xml_file.php';
+
+#[CoversFunction('collectResearcherConfirmationDataFromXml')]
+#[CoversFunction('sendResearcherConfirmationEmails')]
+final class ResearcherConfirmationTest extends TestCase
+{
+    /**
+     * Tests that empty XML returns no title and no contacts.
+     */
+    public function testEmptyXmlReturnsEmptyResult(): void
+    {
+        $result = collectResearcherConfirmationDataFromXml('');
+
+        $this->assertSame('', $result['title']);
+        $this->assertSame([], $result['contacts']);
+    }
+
+    /**
+     * Tests that the dataset title is extracted correctly.
+     */
+    public function testTitleIsExtracted(): void
+    {
+        $xml = '<root><title>My Dataset</title></root>';
+
+        $result = collectResearcherConfirmationDataFromXml($xml);
+
+        $this->assertSame('My Dataset', $result['title']);
+    }
+
+    /**
+     * Tests that a contact is extracted and name is converted.
+     */
+    public function testContactIsExtracted(): void
+    {
+        $xml =
+            '<root>' .
+                '<pointOfContact>' .
+                    '<individualName><CharacterString>Doe, John</CharacterString></individualName>' .
+                    '<electronicMailAddress><CharacterString>john@example.com</CharacterString></electronicMailAddress>' .
+                '</pointOfContact>' .
+            '</root>';
+
+        $result = collectResearcherConfirmationDataFromXml($xml);
+
+        $this->assertCount(1, $result['contacts']);
+
+        $this->assertSame('John Doe', $result['contacts'][0]['fullName']);
+        $this->assertSame('john@example.com', $result['contacts'][0]['email']);
+    }
+
+    /**
+     * Tests that invalid email addresses are skipped.
+     */
+    public function testInvalidEmailIsSkipped(): void
+    {
+        $xml =
+            '<root>' .
+                '<pointOfContact>' .
+                    '<individualName><CharacterString>John Doe</CharacterString></individualName>' .
+                    '<electronicMailAddress><CharacterString>invalid-email</CharacterString></electronicMailAddress>' .
+                '</pointOfContact>' .
+            '</root>';
+
+        $result = collectResearcherConfirmationDataFromXml($xml);
+
+        $this->assertSame([], $result['contacts']);
+    }
+
+    /**
+     * Tests that duplicate contacts are removed.
+     */
+    public function testDuplicateContactsAreRemoved(): void
+    {
+        $xml =
+            '<root>' .
+                '<pointOfContact>' .
+                    '<individualName><CharacterString>Doe, John</CharacterString></individualName>' .
+                    '<electronicMailAddress><CharacterString>john@example.com</CharacterString></electronicMailAddress>' .
+                '</pointOfContact>' .
+                '<pointOfContact>' .
+                    '<individualName><CharacterString>Doe, John</CharacterString></individualName>' .
+                    '<electronicMailAddress><CharacterString>john@example.com</CharacterString></electronicMailAddress>' .
+                '</pointOfContact>' .
+            '</root>';
+
+        $result = collectResearcherConfirmationDataFromXml($xml);
+
+        $this->assertCount(1, $result['contacts']);
+    }
+
+    /**
+     * Tests email generation in simulation mode.
+     */
+    public function testSendResearcherConfirmationEmailsInSimulationMode(): void
+    {
+        $data = [
+            'title' => 'My Dataset',
+            'contacts' => [
+                [
+                    'fullName' => 'John Doe',
+                    'email' => 'john@example.com',
+                ],
+            ],
+        ];
+
+        sendResearcherConfirmationEmails($data, true);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests that invalid email addresses are skipped during email generation.
+     */
+    public function testSendResearcherConfirmationEmailsSkipsInvalidEmail(): void
+    {
+        $data = [
+            'title' => 'My Dataset',
+            'contacts' => [
+                [
+                    'fullName' => 'John Doe',
+                    'email' => 'invalid-email',
+                ],
+            ],
+        ];
+
+        sendResearcherConfirmationEmails($data, true);
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
 Add researcher confirmation emails after successful metadata submission.
 #1012

## Changes

- Added extraction of researcher contact information from the exported XML to prepare confirmation email data (title and unique contacts).
- Implemented sendResearcherConfirmationEmails() to send confirmation emails to all valid researcher contacts, including HTML and plain-text versions, with a static subject and dynamic dataset title.
- Added PHP unit tests for `collectResearcherConfirmationDataFromXml `and `sendResearcherConfirmationEmails`.

## Notes for Reviewer
This implementation affects the submit workflow, so please test it and check the Docker logs to verify that it works.

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None.