### PR TITLE
Fix: Affiliation Identifier deleted when editing Affiliation Name in Authors Form Group

### DIFF
--- a/js/affiliations.js
+++ b/js/affiliations.js
@@ -328,9 +328,15 @@ function autocompleteAffiliations(inputFieldId, hiddenFieldId) {
     return whitelistMatch ? normalizeRorId(whitelistMatch.rorId || whitelistMatch.id) : '';
   }
 
-  function normalizeTag(tag) {
+  function getHiddenRorIds() {
+    return String(hiddenField.val() || '')
+      .split(',')
+      .map(normalizeRorId);
+  }
+
+  function normalizeTag(tag, fallbackRorId = '') {
     const label = getTagLabel(tag);
-    const rorId = normalizeRorId(tag.rorId || tag.id) || findWhitelistRorId(label);
+    const rorId = normalizeRorId(tag.rorId || tag.id) || normalizeRorId(fallbackRorId) || findWhitelistRorId(label);
 
     tag.value = label;
     tag.label = label;
@@ -348,9 +354,10 @@ function autocompleteAffiliations(inputFieldId, hiddenFieldId) {
   /**
    * Updates the visible Tagify field with structured affiliation data and the legacy hidden ROR ID CSV.
    */
-  function syncStructuredAffiliations() {
+  function syncStructuredAffiliations(options = {}) {
+    const fallbackRorIds = options.preserveExistingRorIds ? getHiddenRorIds() : [];
     const structuredAffiliations = tagify.value
-      .map(normalizeTag)
+      .map((tag, index) => normalizeTag(tag, fallbackRorIds[index] || ''))
       .filter(tag => tag.value !== '' || tag.rorId !== '');
 
     inputElement.val(JSON.stringify(structuredAffiliations));
@@ -517,7 +524,7 @@ function autocompleteAffiliations(inputFieldId, hiddenFieldId) {
   });
 
   tagify.on("edit:updated", function () {
-    syncStructuredAffiliations();
+    syncStructuredAffiliations({ preserveExistingRorIds: true });
     scheduleRequirementSync();
     syncAuthorInstitutionRequirement();
   });

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -196,7 +196,7 @@ function fillRowFromOrcidRecord(row, data, fieldMapping) {
       id: rorId
     };
   });
-  const tagifyObjects = affiliationObjects.map(affiliation => ({ value: affiliation.value }));
+  const tagifyObjects = affiliationObjects.map(affiliation => ({ ...affiliation }));
 
   // Set Tagify tags
   const affiliationInput = row.find(`input[id^="${fieldMapping.affiliation}"]`)[0];

--- a/js/eventhandlers/formgroups/authorStack.js
+++ b/js/eventhandlers/formgroups/authorStack.js
@@ -517,6 +517,8 @@ $(document).ready(function () {
 
     if (options.render !== false) {
       renderAffiliationEditor(row);
+    } else {
+      validateAffiliationEditor(row);
     }
 
     return normalizedAffiliations;
@@ -728,7 +730,10 @@ $(document).ready(function () {
       .prop('disabled', index === count - 1)
       .append('<i class="bi bi-chevron-down" aria-hidden="true"></i>');
     const labelInput = $('<input type="text" class="form-control" data-author-affiliation-label>')
-      .attr('aria-label', translate('authors.affiliationEdit', 'Edit affiliation'))
+      .attr({
+        'aria-label': translate('authors.affiliationEdit', 'Edit affiliation'),
+        required: 'required'
+      })
       .val(label);
     const rorSegment = $('<span class="input-group-text small" data-author-affiliation-ror></span>')
       .attr('aria-label', rorId ? `${translate('authors.affiliationRorId', 'ROR ID')} ${rorId}` : translate('authors.affiliationRorId', 'ROR ID'))
@@ -738,8 +743,12 @@ $(document).ready(function () {
       .attr('aria-label', translate('authors.affiliationRemove', 'Remove affiliation'))
       .append('<i class="bi bi-x-lg" aria-hidden="true"></i>');
 
+    const invalidFeedback = $('<div class="invalid-feedback mt-1" data-author-affiliation-invalid></div>');
+
     group.append(moveUp, moveDown, labelInput, rorSegment, remove);
-    return chip.append(group);
+    chip.append(group, invalidFeedback);
+    validateAffiliationChip(chip);
+    return chip;
   }
 
   function renderAffiliationEditor(row) {
@@ -770,26 +779,65 @@ $(document).ready(function () {
     });
   }
 
-  function clearAffiliationRorIfLabelChanged(labelInput) {
-    const input = $(labelInput);
-    const chip = input.closest('[data-author-affiliation-chip]');
-    const originalLabel = chip.attr('data-author-affiliation-original-label') || '';
-    const currentLabel = String(input.val() || '').trim();
+  function getAffiliationInvalidMessage() {
+    return translate('authors.affiliationInvalid', 'Please provide an affiliation.');
+  }
 
-    if (!originalLabel || currentLabel === originalLabel) {
-      return;
+  function validateAffiliationChip(chip) {
+    const labelInput = chip.find('[data-author-affiliation-label]').first();
+    const inputElement = labelInput.get(0);
+    const feedback = chip.find('[data-author-affiliation-invalid]').first();
+    const label = String(labelInput.val() || '').trim();
+    const isInvalid = label === '';
+    const message = isInvalid ? getAffiliationInvalidMessage() : '';
+
+    labelInput.toggleClass('is-invalid', isInvalid);
+    chip.toggleClass('border-danger', isInvalid);
+
+    if (inputElement) {
+      inputElement.setCustomValidity(message);
+      if (isInvalid) {
+        inputElement.setAttribute('aria-invalid', 'true');
+      } else {
+        inputElement.removeAttribute('aria-invalid');
+      }
     }
 
-    chip.attr('data-author-affiliation-ror-id', '');
-    chip.removeAttr('data-author-affiliation-original-label');
-    chip.find('[data-author-affiliation-ror]')
-      .text('')
-      .addClass('d-none')
-      .attr('aria-label', translate('authors.affiliationRorId', 'ROR ID'));
+    feedback
+      .text(message)
+      .toggleClass('d-block', isInvalid)
+      .toggleClass('d-none', !isInvalid);
+
+    return !isInvalid;
+  }
+
+  function validateAffiliationEditor(row) {
+    let isValid = true;
+
+    row.find('[data-author-affiliation-chip]').each(function () {
+      if (!validateAffiliationChip($(this))) {
+        isValid = false;
+      }
+    });
+
+    return isValid;
+  }
+
+  function validateAuthorAffiliationEditors() {
+    let isValid = true;
+
+    stack.children('[data-author-entry-row]').each(function () {
+      if (!validateAffiliationEditor($(this))) {
+        isValid = false;
+      }
+    });
+
+    return isValid;
   }
 
   function syncEditorAffiliations(row) {
     setRowAffiliations(row, readEditorAffiliations(row), { render: false });
+    validateAffiliationEditor(row);
     updatePayload();
   }
 
@@ -1310,7 +1358,6 @@ $(document).ready(function () {
   });
 
   stack.on('input', '[data-author-affiliation-label]', function () {
-    clearAffiliationRorIfLabelChanged(this);
     syncEditorAffiliations($(this).closest('[data-author-entry-row]'));
   });
 
@@ -1424,12 +1471,15 @@ $(document).ready(function () {
     updateSummary(collectPayload());
   });
 
+  window.validateAuthorAffiliationEditors = validateAuthorAffiliationEditors;
+
   window.authorStack = {
     addPerson: function () { return addRow('person'); },
     addInstitution: function () { return addRow('institution'); },
     setAuthors,
     updatePayload,
-    collectPayload
+    collectPayload,
+    validateAffiliationEditors: validateAuthorAffiliationEditors
   };
 
   updatePayload();

--- a/js/saveHandler.js
+++ b/js/saveHandler.js
@@ -118,6 +118,9 @@ class SaveHandler {
     async handleSave(format = 'xml') {
         this.saveFlowStartedAt = Date.now();
         this.setCurrentFormat(format);
+        if (!this.validateAuthorAffiliationsForSave()) {
+            return;
+        }
         this.updateSaveAsModal();
         this.showNotification('info',
             translations.alerts.processingHeading,
@@ -127,6 +130,29 @@ class SaveHandler {
             $('#input-saveas-filename').val(suggestedFilename);
             this.modals.saveAs.show();
         }
+    }
+
+    validateAuthorAffiliationsForSave() {
+        const validator = typeof globalThis !== 'undefined'
+            ? globalThis.validateAuthorAffiliationEditors
+            : null;
+
+        if (typeof validator !== 'function' || validator()) {
+            return true;
+        }
+
+        const firstInvalid = this.$form.find('[data-author-affiliation-label].is-invalid').first();
+        if (firstInvalid.length > 0 && firstInvalid[0]) {
+            firstInvalid[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+            firstInvalid[0].focus();
+        }
+
+        this.showNotification(
+            'danger',
+            translations.alerts.validationErrorheading || translations.alerts.errorHeading,
+            translations.alerts.validationError || translations.alerts.saveError
+        );
+        return false;
     }
 
     /**

--- a/js/submitHandler.js
+++ b/js/submitHandler.js
@@ -410,7 +410,11 @@ class SubmitHandler {
         validateTitleField();
         validateAuthorNameFields();
         const temporalCoverageValid = validateAllTemporalCoverageRows();
-        if (!this.$form[0].checkValidity() || !validateContactPerson() || !temporalCoverageValid) {
+        const authorAffiliationsValid = typeof globalThis !== 'undefined'
+            && typeof globalThis.validateAuthorAffiliationEditors === 'function'
+            ? globalThis.validateAuthorAffiliationEditors()
+            : true;
+        if (!this.$form[0].checkValidity() || !validateContactPerson() || !temporalCoverageValid || !authorAffiliationsValid) {
             this.$form.addClass('was-validated');
             const $firstInvalid = this.$form.find(':invalid').first();
             if ($firstInvalid.length > 0 && $firstInvalid[0]) {

--- a/tests/SaveAuthorsTest.php
+++ b/tests/SaveAuthorsTest.php
@@ -1212,6 +1212,53 @@ final class SaveAuthorsTest extends DatabaseTestCase
         $this->assertEquals($legacyId, $rows[0]['author_person_id'], 'The pre-existing legacy author ID should be reused.');
     }
 
+    public function testSaveAuthorsPayloadPreservesEditedAffiliationLabelAndRorId(): void
+    {
+        $resource_id = $this->createResource('GFZ.TEST.AUTHOR.EDITED.AFFILIATION.ROR', 'Test Edited Affiliation ROR');
+
+        $authorData = [
+            'authorsPayload' => json_encode([
+                [
+                    'type' => 'person',
+                    'familyname' => 'EditedAffiliation',
+                    'givenname' => 'Author',
+                    'orcid' => '',
+                    'isContact' => false,
+                    'affiliations' => [
+                        [
+                            'label' => 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany',
+                            'rorId' => 'https://ror.org/04z8jg394'
+                        ]
+                    ]
+                ]
+            ]),
+            'familynames' => ['EditedAffiliation'],
+            'givennames' => ['Author'],
+            'orcids' => [''],
+            'personAffiliation' => [''],
+            'authorPersonRorIds' => ['']
+        ];
+
+        saveAuthors($this->connection, $authorData, $resource_id);
+
+        $stmt = $this->connection->prepare(
+            'SELECT af.name, af.rorId
+             FROM Affiliation af
+             JOIN Author_has_Affiliation aha ON af.affiliation_id = aha.Affiliation_affiliation_id
+             JOIN Author a ON aha.Author_author_id = a.author_id
+             JOIN Author_person ap ON a.Author_Person_author_person_id = ap.author_person_id
+             WHERE ap.familyname = ? AND ap.givenname = ?'
+        );
+        $familyname = 'EditedAffiliation';
+        $givenname = 'Author';
+        $stmt->bind_param('ss', $familyname, $givenname);
+        $stmt->execute();
+        $affiliation = $stmt->get_result()->fetch_assoc();
+
+        $this->assertSame('GFZ Helmholtz Centre for Geosciences, Potsdam, Germany', $affiliation['name']);
+        $this->assertSame('04z8jg394', $affiliation['rorId']);
+    }
+
     public function testSaveAuthorsPreservesMixedAuthorsPayloadOrder(): void
     {
         $resource_id = $this->createResource('GFZ.TEST.MIXED.AUTHOR.PAYLOAD.ORDER', 'Test Mixed Author Payload Order');

--- a/tests/js/affiliations.test.js
+++ b/tests/js/affiliations.test.js
@@ -217,6 +217,31 @@ describe('affiliations.js', () => {
     ]);
   });
 
+  test('editing an affiliation label restores the ROR ID from the hidden field when Tagify drops it', () => {
+    autocompleteAffiliations('input-author-affiliation', 'input-author-rorid');
+    const input = document.getElementById('input-author-affiliation');
+    const hidden = document.getElementById('input-author-rorid');
+
+    input._tagify.addTags([{ value: 'GFZ Helmholtz Centre for Geosciences', id: '04z8jg394' }]);
+    input._tagify._updateHiddenField();
+    expect(hidden.value).toBe('04z8jg394');
+
+    input._tagify.value[0] = {
+      value: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany'
+    };
+    input._tagify.trigger('edit:updated', { data: input._tagify.value[0] });
+
+    expect(hidden.value).toBe('04z8jg394');
+    expect(JSON.parse(input.value)).toEqual([
+      {
+        value: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany',
+        label: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany',
+        rorId: '04z8jg394',
+        id: '04z8jg394'
+      }
+    ]);
+  });
+
   /**
    * Checks that the remove event clears tags when no contact person is specified.
    */

--- a/tests/js/authorStack.test.js
+++ b/tests/js/authorStack.test.js
@@ -457,9 +457,10 @@ describe('authorStack.js', () => {
       .trigger('input');
     expect(payload()[0].affiliations[0]).toEqual({
       label: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany',
-      rorId: ''
+      rorId: '04z8jg394'
     });
-    expect(editor.find('[data-author-affiliation-ror]').first().hasClass('d-none')).toBe(true);
+    expect(editor.find('[data-author-affiliation-ror]').first().hasClass('d-none')).toBe(false);
+    expect(editor.find('[data-author-affiliation-ror]').first().text()).toBe('04z8jg394');
 
     editor.find('[data-author-affiliation-input]').val('Visiting researcher, ETH Zürich (2025)').trigger('input');
     editor.find('[data-author-affiliation-add]').trigger('click');
@@ -477,6 +478,41 @@ describe('authorStack.js', () => {
 
     editor.find('[data-author-affiliation-remove]').last().trigger('click');
     expect(payload()[0].affiliations).toHaveLength(2);
+  });
+
+  test('keeps a ROR affiliation invalid but intact when its label is emptied', () => {
+    window.authorStack.setAuthors([
+      {
+        type: 'person',
+        familyname: 'Doe',
+        givenname: 'Jane',
+        affiliations: [
+          { label: 'GFZ Helmholtz Centre for Geosciences', rorId: '04z8jg394' }
+        ]
+      }
+    ]);
+
+    const editor = $('[data-author-card]').first().find('[data-author-affiliation-editor]');
+    const chip = editor.find('[data-author-affiliation-chip]').first();
+    const labelInput = chip.find('[data-author-affiliation-label]');
+
+    labelInput.val('').trigger('input');
+
+    expect(payload()[0].affiliations[0]).toEqual({
+      label: '',
+      rorId: '04z8jg394'
+    });
+    expect(chip.find('[data-author-affiliation-ror]').text()).toBe('04z8jg394');
+    expect(chip.find('[data-author-affiliation-ror]').hasClass('d-none')).toBe(false);
+    expect(labelInput.hasClass('is-invalid')).toBe(true);
+    expect(labelInput[0].checkValidity()).toBe(false);
+    expect(window.validateAuthorAffiliationEditors()).toBe(false);
+
+    chip.find('[data-author-affiliation-remove]').trigger('click');
+
+    expect(payload()[0].affiliations).toEqual([]);
+    expect($('[data-author-affiliation-chip]').length).toBe(0);
+    expect(window.validateAuthorAffiliationEditors()).toBe(true);
   });
 
   test('searches affiliation suggestions while typing at least three characters', async () => {

--- a/tests/js/autocomplete.test.js
+++ b/tests/js/autocomplete.test.js
@@ -28,6 +28,16 @@ class MockTagify {
 
 const flushPromises = () => new Promise(res => setTimeout(res, 0));
 
+function expectedAffiliation(name, rorId) {
+  const normalizedRorId = rorId.startsWith('https://ror.org/') ? rorId : `https://ror.org/${rorId}`;
+  return {
+    value: name,
+    label: name,
+    rorId: normalizedRorId,
+    id: normalizedRorId
+  };
+}
+
 function createAffiliationSummary(type, name, rorId, endDate = null) {
   const summary = {
     organization: {
@@ -169,7 +179,7 @@ describe('autocomplete.js', () => {
     expect(fetch).toHaveBeenCalled();
     expect($('#group-author input[name="familynames[]"]').val()).toBe('Doe');
     expect($('#group-author input[name="givennames[]"]').val()).toBe('John');
-    expect(affInput._tagify.value).toEqual([{ value: 'Current Lab' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Current Lab', '05rrcem69')]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/05rrcem69');
   });
 
@@ -209,7 +219,7 @@ describe('autocomplete.js', () => {
     });
     expect($('#group-author input[name="familynames[]"]').val()).toBe('Reference');
     expect($('#group-author input[name="givennames[]"]').val()).toBe('Case');
-    expect(affInput._tagify.value).toEqual([{ value: 'Expected Current Affiliation' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Expected Current Affiliation', '0arefcase1')]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/0arefcase1');
   });
 
@@ -247,7 +257,7 @@ describe('autocomplete.js', () => {
     });
     expect($('#group-author input[name="familynames[]"]').val()).toBe('Reference');
     expect($('#group-author input[name="givennames[]"]').val()).toBe('Case');
-    expect(affInput._tagify.value).toEqual([{ value: 'Expected Current Affiliation' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Expected Current Affiliation', '0arefcase1')]);
   });
 
   test('author ORCID blur keeps two current affiliations', async () => {
@@ -286,8 +296,8 @@ describe('autocomplete.js', () => {
     await flushPromises();
 
     expect(affInput._tagify.value).toEqual([
-      { value: 'Institute One' },
-      { value: 'Institute Two' }
+      expectedAffiliation('Institute One', '01aaa1111'),
+      expectedAffiliation('Institute Two', '02bbb2222')
     ]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/01aaa1111,https://ror.org/02bbb2222');
   });
@@ -330,8 +340,8 @@ describe('autocomplete.js', () => {
     await flushPromises();
 
     expect(affInput._tagify.value).toEqual([
-      { value: 'Current Institute' },
-      { value: 'Current University' }
+      expectedAffiliation('Current Institute', '05eee5555'),
+      expectedAffiliation('Current University', '04ddd4444')
     ]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/05eee5555,https://ror.org/04ddd4444');
   });
@@ -374,7 +384,7 @@ describe('autocomplete.js', () => {
     await flushPromises();
     await flushPromises();
 
-    expect(affInput._tagify.value).toEqual([{ value: 'Current Org' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Current Org', '09iii9999')]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/09iii9999');
   });
 
@@ -438,7 +448,7 @@ describe('autocomplete.js', () => {
 
     expect($('#group-contributorperson input[name="cbPersonLastname[]"]').val()).toBe('Smith');
     expect($('#group-contributorperson input[name="cbPersonFirstname[]"]').val()).toBe('Anna');
-    expect(affInput._tagify.value).toEqual([{ value: 'Lab B' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Lab B', '0anewlab1')]);
     expect(document.getElementById('input-contributor-personrorid').value).toBe('https://ror.org/0anewlab1');
   });
 
@@ -476,7 +486,7 @@ describe('autocomplete.js', () => {
     });
     expect($('#group-contributorperson input[name="cbPersonLastname[]"]').val()).toBe('Smith');
     expect($('#group-contributorperson input[name="cbPersonFirstname[]"]').val()).toBe('Anna');
-    expect(affInput._tagify.value).toEqual([{ value: 'Lab B' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Lab B', '0anewlab1')]);
   });
 
   test('fillRowFromOrcidRecord fills author row with name and affiliations', () => {
@@ -505,7 +515,7 @@ describe('autocomplete.js', () => {
 
     expect($('#group-author input[name="familynames[]"]').val()).toBe('Einstein');
     expect($('#group-author input[name="givennames[]"]').val()).toBe('Albert');
-    expect(affInput._tagify.value).toEqual([{ value: 'ETH Zurich' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('ETH Zurich', '01ror0001')]);
     expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/01ror0001');
   });
 
@@ -535,7 +545,7 @@ describe('autocomplete.js', () => {
 
     expect($('#group-contributorperson input[name="cbPersonLastname[]"]').val()).toBe('Curie');
     expect($('#group-contributorperson input[name="cbPersonFirstname[]"]').val()).toBe('Marie');
-    expect(affInput._tagify.value).toEqual([{ value: 'Sorbonne' }]);
+    expect(affInput._tagify.value).toEqual([expectedAffiliation('Sorbonne', '02ror0002')]);
     expect(document.getElementById('input-contributor-personrorid').value).toBe('https://ror.org/02ror0002');
   });
 

--- a/tests/js/orcidSearch.test.js
+++ b/tests/js/orcidSearch.test.js
@@ -650,7 +650,12 @@ describe('orcidSearch.js', () => {
       expect($('input[name="familynames[]"]').val()).toBe('Curie');
       expect($('input[name="givennames[]"]').val()).toBe('Marie');
       // Check affiliations
-      expect(affInput._tagify.value).toEqual([{ value: 'Sorbonne University' }]);
+      expect(affInput._tagify.value).toEqual([{
+        value: 'Sorbonne University',
+        label: 'Sorbonne University',
+        rorId: 'https://ror.org/02en5vm52',
+        id: 'https://ror.org/02en5vm52'
+      }]);
       expect(document.getElementById('input-author-rorid').value).toBe('https://ror.org/02en5vm52');
     });
 
@@ -700,7 +705,12 @@ describe('orcidSearch.js', () => {
       expect($('input[name="cbORCID[]"]').val()).toBe('0000-0002-7777-8888');
       expect($('input[name="cbPersonLastname[]"]').val()).toBe('Turing');
       expect($('input[name="cbPersonFirstname[]"]').val()).toBe('Alan');
-      expect(affInput._tagify.value).toEqual([{ value: 'University of Cambridge' }]);
+      expect(affInput._tagify.value).toEqual([{
+        value: 'University of Cambridge',
+        label: 'University of Cambridge',
+        rorId: 'https://ror.org/01aaaa111',
+        id: 'https://ror.org/01aaaa111'
+      }]);
       expect(document.getElementById('input-contributor-personrorid').value).toBe('https://ror.org/01aaaa111');
     });
 

--- a/tests/js/saveHandler.test.js
+++ b/tests/js/saveHandler.test.js
@@ -58,6 +58,8 @@ describe('saveHandler.js', () => {
       alerts: {
         processingHeading: 'procH',
         preparingDownload: 'prepD',
+        validationErrorheading: 'vh',
+        validationError: 've',
         filenameErrorHeading: 'fh',
         filenameError: 'fe',
         successHeading: 'sh',
@@ -80,6 +82,7 @@ describe('saveHandler.js', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    delete global.validateAuthorAffiliationEditors;
   });
 
   test('generateFilename returns formatted timestamp', async () => {
@@ -131,6 +134,20 @@ describe('saveHandler.js', () => {
     expect($('#saveas-extension').text()).toBe('.jsonld');
     expect($('#input-saveas-filename').val()).toBe('dataset_20240530_123456');
     expect(modalInstances[0].show).toHaveBeenCalled();
+  });
+
+  test('handleSave blocks download flow when author affiliation labels are invalid', async () => {
+    global.validateAuthorAffiliationEditors = jest.fn().mockReturnValue(false);
+    const handler = new SaveHandler('form-mde', 'modal-saveas', 'modal-notification');
+    jest.spyOn(handler, 'generateFilename').mockResolvedValue('dataset_20240530_123456');
+    jest.spyOn(handler, 'showNotification').mockImplementation(() => {});
+
+    await handler.handleSave('xml');
+
+    expect(global.validateAuthorAffiliationEditors).toHaveBeenCalled();
+    expect(handler.generateFilename).not.toHaveBeenCalled();
+    expect(handler.showNotification).toHaveBeenCalledWith('danger', 'vh', 've');
+    expect(modalInstances[0].show).not.toHaveBeenCalled();
   });
 
   test('showNotification updates modal and hides on actions', () => {

--- a/tests/js/submitHandler.test.js
+++ b/tests/js/submitHandler.test.js
@@ -102,6 +102,7 @@ describe('submitHandler.js', () => {
     console.error.mockRestore();
     delete global.validateTitleField;
     delete global.validateAuthorNameFields;
+    delete global.validateAuthorAffiliationEditors;
   });
 
   test('validateEmbargoDate marks invalid when embargo before creation', () => {
@@ -656,6 +657,21 @@ describe('submitHandler.js', () => {
     handler.handleSubmit();
     expect(modalSpy).toHaveBeenCalled();
     expect(notifSpy).not.toHaveBeenCalled();
+  });
+
+  test('handleSubmit shows validation-failed modal when author affiliation labels are invalid', () => {
+    global.validateAuthorAffiliationEditors = jest.fn().mockReturnValue(false);
+    handler.$form[0].checkValidity = jest.fn().mockReturnValue(true);
+    document.getElementById('group-author').innerHTML = `
+      <input type="hidden" name="authorsPayload" value='[{"type":"person","familyname":"Doe","givenname":"Jane","email":"jane@example.org","isContact":true}]'>
+      <input type="checkbox" name="contacts[]" id="checkbox-author-contactperson-1">
+    `;
+
+    const modalSpy = jest.spyOn(handler, 'showValidationFailedModal');
+    handler.handleSubmit();
+
+    expect(global.validateAuthorAffiliationEditors).toHaveBeenCalled();
+    expect(modalSpy).toHaveBeenCalled();
   });
 
   test('handleSubmit shows validation-failed modal when contact person is missing', () => {

--- a/tests/playwright/features/affiliations-editing.spec.ts
+++ b/tests/playwright/features/affiliations-editing.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
 import { XMLParser } from 'fast-xml-parser';
-import { completeMinimalDatasetForm, navigateToHome } from '../utils';
+import { completeMinimalDatasetForm, navigateToHome, runAxeAudit } from '../utils';
 
 // ─── selectors ────────────────────────────────────────────────────────────────
 const AUTHOR_GROUP     = '#group-author';
@@ -177,11 +177,11 @@ test.describe('Affiliation tag label editing', () => {
   /**
    * Test 1 – comprehensive:
    * - A tag selected from the whitelist initially carries a ROR id in the editor.
-   * - Editing that tag's label removes the original ROR id to avoid stale name/ROR pairs.
+   * - Editing that tag's label preserves the original ROR id.
    * - A free-text tag (added without selecting from the dropdown) has no ROR id.
    */
   test(
-    'whitelist-selected affiliation drops ROR after manual label edit; free-text tag has no ROR',
+    'whitelist-selected affiliation preserves ROR after manual label edit; free-text tag has no ROR',
     async ({ page }) => {
       test.slow();
 
@@ -208,13 +208,13 @@ test.describe('Affiliation tag label editing', () => {
 
       // ── Assertions ─────────────────────────────────────────────────────────
 
-      // Edited tag: label must reflect the rename and no longer carry the stale ROR id
+      // Edited tag: label must reflect the rename and keep the selected ROR id
       const editedEntry = affiliations.find(a => a.label === editedLabel);
       expect(editedEntry, `Expected affiliation "${editedLabel}" in XML`).toBeDefined();
       expect(
         editedEntry?.id,
-        'Edited tag must not keep the old ROR identifier after a manual label change',
-      ).toBeUndefined();
+        'Edited tag must keep its ROR identifier after a manual label change',
+      ).toBe(`https://ror.org/${selected.id}`);
 
       // Free-text tag (added by completeMinimalDatasetForm): no ROR
       const freeTextEntry = affiliations.find(
@@ -228,6 +228,42 @@ test.describe('Affiliation tag label editing', () => {
         freeTextEntry?.id,
         'Free-text affiliation must not carry an affiliationIdentifier',
       ).toBeUndefined();
+    },
+  );
+
+  test(
+    'empty edited author affiliation label blocks save and keeps ROR visible',
+    async ({ page }) => {
+      test.slow();
+
+      await completeMinimalDatasetForm(page);
+
+      const selected = await selectAffiliationFromDropdown(page, 'tu berlin');
+      await editAffiliationLabel(page, selected.value, '');
+
+      const authorRow = page.locator(`${AUTHOR_GROUP} [data-creator-row]`).first();
+      const chip = authorRow
+        .locator(`[data-author-affiliation-chip][data-author-affiliation-ror-id="${selected.id}"]`)
+        .first();
+      const labelInput = chip.locator('[data-author-affiliation-label]');
+      const rorSegment = chip.locator('[data-author-affiliation-ror]');
+
+      await expect(labelInput).toHaveValue('');
+      await expect(rorSegment).toBeVisible();
+      await expect(rorSegment).toHaveText(selected.id);
+
+      await page.locator('#button-form-save').click();
+
+      await expect(page.locator('#modal-saveas')).not.toBeVisible();
+      await expect(labelInput).toHaveClass(/is-invalid/);
+      await expect(labelInput).toHaveAttribute('aria-invalid', 'true');
+      await expect(chip.locator('[data-author-affiliation-invalid]')).toBeVisible();
+      await expect(rorSegment).toBeVisible();
+      await expect(rorSegment).toHaveText(selected.id);
+
+      await runAxeAudit(page, {
+        configure: (builder) => builder.include(AUTHOR_GROUP),
+      });
     },
   );
 


### PR DESCRIPTION
This pull request introduces significant improvements to author affiliation handling, validation, and data consistency throughout the author entry and save/submit workflows. The changes ensure that edited affiliations retain their ROR IDs, enforce required affiliation labels with clear validation feedback, and enhance test coverage for these behaviors. The most important changes are grouped below:

## Changes
### Affiliation Data Consistency and ROR ID Preservation
* The `normalizeTag` and `syncStructuredAffiliations` functions in `js/affiliations.js` were updated to preserve and restore ROR IDs when editing affiliation labels, even if the Tagify widget drops them. This ensures that affiliation edits do not lose their associated ROR IDs. [[1]](diffhunk://#diff-1a9f035fce8eded54e52feca3a13e03085a4b2a8e1a85d5e264085cb3ec5de81L331-R339) [[2]](diffhunk://#diff-1a9f035fce8eded54e52feca3a13e03085a4b2a8e1a85d5e264085cb3ec5de81L351-R360) [[3]](diffhunk://#diff-1a9f035fce8eded54e52feca3a13e03085a4b2a8e1a85d5e264085cb3ec5de81L520-R527)
* The logic for mapping ORCID affiliations now includes all affiliation fields (label and ROR ID), ensuring Tagify objects are populated with complete data.

### Affiliation Editor Validation and User Feedback
* The author affiliation editor UI now enforces that affiliation labels are required, provides real-time validation feedback, and displays an error message if the field is empty. The validation state is visually indicated and accessible (ARIA attributes updated). [[1]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3L731-R736) [[2]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3R746-R751) [[3]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3L773-R840)
* The validation logic is exposed globally via `window.validateAuthorAffiliationEditors` and integrated into author stack operations, so that all affiliation editors in the form are validated together. [[1]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3R520-R521) [[2]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3L1313) [[3]](diffhunk://#diff-a467596a05b49aa2f6b138b648753542cff770269599de651c7bb8b4d6bb8ba3R1474-R1482)

### Save and Submit Workflow Integration
* Both the save (`js/saveHandler.js`) and submit (`js/submitHandler.js`) handlers now invoke author affiliation validation before proceeding. If validation fails, the first invalid field is focused and a notification is shown, preventing incomplete or invalid data from being saved or submitted. [[1]](diffhunk://#diff-09eb1ba8869156e52146b45ee3285e3b81225ed8f680df0f44c9af03e4b137eaR121-R123) [[2]](diffhunk://#diff-09eb1ba8869156e52146b45ee3285e3b81225ed8f680df0f44c9af03e4b137eaR135-R157) [[3]](diffhunk://#diff-8f21631a98813c3dbda9cd2abbde76214f739fb4f6751c1769497367ab678703L413-R417)

### Test Coverage and Reliability
* New and updated tests in `tests/js/affiliations.test.js`, `tests/js/authorStack.test.js`, and `tests/js/autocomplete.test.js` verify that affiliation edits preserve ROR IDs, validation behaves as expected, and the UI correctly reflects the validation state. [[1]](diffhunk://#diff-e6444cfd5ecccf5b63e0d0f08e16e1b508411507a9b826c58e197073dec183e4R220-R244) [[2]](diffhunk://#diff-793d30bc6a2f3e20c96720f6c124b29d4033d3c9d7afaf5d579b5a317935634eL460-R463) [[3]](diffhunk://#diff-793d30bc6a2f3e20c96720f6c124b29d4033d3c9d7afaf5d579b5a317935634eR483-R517) [[4]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eR31-R40) [[5]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eL172-R182) [[6]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eL212-R222) [[7]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eL250-R260) [[8]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eL289-R300) [[9]](diffhunk://#diff-af1ab30641e7708dd5f3beca298f6f9a18d69d54b0b82723b1b90045cb18750eL333-R344)
* A new backend test ensures that edited affiliation labels and ROR IDs are preserved in the saved payload.

## Notes for Reviewer
None.

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None.
