### PR TITLE
Fix: thesaurus keyword upload and modal sync

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -33,6 +33,8 @@
                             <li>ELMO-GEM spatial coverage can be submitted without temporal coverage while keeping the description required</li>
                             <li>Date-only spatial temporal coverage values are preserved during save, download and upload roundtrips</li>
                             <li>ICGEM metadata upload now imports Date Created and contact person details more reliably</li>
+                            <li>Thesaurus keyword upload works independently per thesaurus and imported keywords are synced to the modal selection</li>
+                            <li>Fixed GEMET thesaurus selection.</li>
                         </ul>
                     </li>
                 </ul>

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -1365,8 +1365,10 @@ function processDates(xmlDoc, resolver) {
  * @param {Function} resolver - The namespace resolver function
  */
 function processKeywords(xmlDoc, resolver) {
+  // Collect all subject nodes from the XML
   const subjectNodes = xmlDoc.evaluate(".//ns:subjects/ns:subject", xmlDoc, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
 
+  // Map each keyword group to its Tagify instance (if available)
   const tagifyMap = {
     free: document.querySelector("#input-freekeyword")?._tagify || null,
     msl: document.querySelector("#input-mslkeyword")?._tagify || null,
@@ -1377,6 +1379,7 @@ function processKeywords(xmlDoc, resolver) {
     gemet: document.querySelector("#input-gemet")?._tagify || null,
   };
 
+  // Keep only initialized Tagify fields
   const allTagifyInstances = Object.values(tagifyMap).filter(Boolean);
 
   if (allTagifyInstances.length === 0) {
@@ -1384,6 +1387,7 @@ function processKeywords(xmlDoc, resolver) {
     return;
   }
 
+  // Clear existing tags before importing new ones
   allTagifyInstances.forEach(tagify => tagify.removeAllTags());
 
   function buildTagData(subjectNode) {
@@ -1413,6 +1417,7 @@ function processKeywords(xmlDoc, resolver) {
     };
   }
 
+  // Resolve which form group a subject belongs to
   function resolveTargetGroup(subjectScheme, schemeURI) {
     if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords") {
       return "gcmdScience";
@@ -1451,6 +1456,7 @@ function processKeywords(xmlDoc, resolver) {
     const targetGroup = resolveTargetGroup(subjectScheme, schemeURI);
     const targetTagify = tagifyMap[targetGroup];
 
+    // Ignore keywords if the target form group is disabled
     if (!targetTagify) {
       continue;
     }

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -1365,38 +1365,28 @@ function processDates(xmlDoc, resolver) {
  * @param {Function} resolver - The namespace resolver function
  */
 function processKeywords(xmlDoc, resolver) {
-  const subjectNodes = xmlDoc.evaluate(".//ns:subjects/ns:subject", xmlDoc, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+  const subjectNodes = xmlDoc.evaluate(".//ns:subjects/ns:subject", xmlDoc, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
 
-  // Thesaurus inputs — may not exist if the thesaurus is disabled via ERNIE availability
-  const tagifyInputGCMD = document.querySelector("#input-sciencekeyword");
-  const tagifyInputPlatforms = document.querySelector("#input-platforms");
-  const tagifyInputInstruments = document.querySelector("#input-instruments");
-  const tagifyInputChronostrat = document.querySelector("#input-chronostratigraphy");
-  const tagifyInputGemet = document.querySelector("#input-gemet");
+  const tagifyMap = {
+    free: document.querySelector("#input-freekeyword")?._tagify || null,
+    msl: document.querySelector("#input-mslkeyword")?._tagify || null,
+    gcmdScience: document.querySelector("#input-sciencekeyword")?._tagify || null,
+    gcmdPlatforms: document.querySelector("#input-platforms")?._tagify || null,
+    gcmdInstruments: document.querySelector("#input-instruments")?._tagify || null,
+    chronostrat: document.querySelector("#input-chronostratigraphy")?._tagify || null,
+    gemet: document.querySelector("#input-gemet")?._tagify || null,
+  };
 
-  // Always-present inputs
-  const tagifyInputMsl = document.querySelector("#input-mslkeyword");
-  const tagifyInputFree = document.querySelector("#input-freekeyword");
+  const allTagifyInstances = Object.values(tagifyMap).filter(Boolean);
 
-  if (!tagifyInputFree?._tagify) {
-    console.error("Free keyword Tagify instance is not properly initialized.");
+  if (allTagifyInstances.length === 0) {
+    console.error("No Tagify instance is properly initialized.");
     return;
   }
 
-  const tagifyFree = tagifyInputFree._tagify;
-  const tagifyMsl = tagifyInputMsl?._tagify;
+  allTagifyInstances.forEach(tagify => tagify.removeAllTags());
 
-  // Clear existing tags on all available inputs
-  tagifyFree.removeAllTags();
-  tagifyMsl?.removeAllTags();
-  tagifyInputGCMD?._tagify?.removeAllTags();
-  tagifyInputPlatforms?._tagify?.removeAllTags();
-  tagifyInputInstruments?._tagify?.removeAllTags();
-  tagifyInputChronostrat?._tagify?.removeAllTags();
-  tagifyInputGemet?._tagify?.removeAllTags();
-
-  for (let i = 0; i < subjectNodes.snapshotLength; i++) {
-    const subjectNode = subjectNodes.snapshotItem(i);
+  function buildTagData(subjectNode) {
     const subjectScheme = subjectNode.getAttribute("subjectScheme") || "";
     const schemeURI = subjectNode.getAttribute("schemeURI") || "";
     const valueURI = subjectNode.getAttribute("valueURI") || "";
@@ -1409,40 +1399,63 @@ function processKeywords(xmlDoc, resolver) {
       schemeURI: schemeURI,
       id: valueURI,
     };
+
     if (language) {
       tagData.language = language;
     }
 
-    // Route tag to appropriate Tagify instance based on schemeURI
+    return {
+      subjectScheme,
+      schemeURI,
+      valueURI,
+      keyword,
+      tagData,
+    };
+  }
+
+  function resolveTargetGroup(subjectScheme, schemeURI) {
     if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords") {
-      if (tagifyInputGCMD?._tagify) tagifyInputGCMD._tagify.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms") {
-      if (tagifyInputPlatforms?._tagify) tagifyInputPlatforms._tagify.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments") {
-      if (tagifyInputInstruments?._tagify) tagifyInputInstruments._tagify.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else if (
-      schemeURI === "http://resource.geosciml.org/vocabulary/timescale/gts2020" ||
-      subjectScheme === "International Chronostratigraphic Chart" ||
-      subjectScheme === "Chronostratigraphic Chart"
-    ) {
-      if (tagifyInputChronostrat?._tagify) tagifyInputChronostrat._tagify.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else if (
-      schemeURI === "http://www.eionet.europa.eu/gemet/gemetThesaurus" ||
-      schemeURI === "http://www.eionet.europa.eu/gemet/concept/" ||
-      subjectScheme?.includes("GEMET")
-    ) {
-      if (tagifyInputGemet?._tagify) tagifyInputGemet._tagify.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else if (schemeURI.startsWith("https://epos-msl.uu.nl/voc/")) {
-      if (tagifyMsl) tagifyMsl.addTags([tagData]);
-      else tagifyFree.addTags([tagData]);
-    } else {
-      tagifyFree.addTags([tagData]);
+      return "gcmdScience";
     }
+
+    if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms") {
+      return "gcmdPlatforms";
+    }
+
+    if (schemeURI === "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments") {
+      return "gcmdInstruments";
+    }
+
+    if (schemeURI === "http://resource.geosciml.org/vocabulary/timescale/gts2020") {
+      return "chronostrat";
+    }
+
+    if (
+      schemeURI === "http://www.eionet.europa.eu/gemet/gemetThesaurus" ||
+      schemeURI === "http://www.eionet.europa.eu/gemet/concept/"
+    ) {
+      return "gemet";
+    }
+
+    if (schemeURI.startsWith("https://epos-msl.uu.nl/voc/")) {
+      return "msl";
+    }
+
+    return "free";
+  }
+
+  for (let i = 0; i < subjectNodes.snapshotLength; i++) {
+    const subjectNode = subjectNodes.snapshotItem(i);
+    const { subjectScheme, schemeURI, tagData } = buildTagData(subjectNode);
+
+    const targetGroup = resolveTargetGroup(subjectScheme, schemeURI);
+    const targetTagify = tagifyMap[targetGroup];
+
+    if (!targetTagify) {
+      continue;
+    }
+
+    targetTagify.addTags([tagData]);
   }
 }
 

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -1383,7 +1383,7 @@ function processKeywords(xmlDoc, resolver) {
   const allTagifyInstances = Object.values(tagifyMap).filter(Boolean);
 
   if (allTagifyInstances.length === 0) {
-    console.error("No Tagify instance is properly initialized.");
+    console.error("No keyword Tagify instances are initialized, upload cannot import subjects.");
     return;
   }
 

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -349,6 +349,7 @@ function loadKeywordsForConfig(config, response) {
         const activeTagify = getActiveTagifyForState(state);
         if (!activeTagify || !activeTagify.value || !activeTagify.value.length) return;
 
+        // Sync jsTree selection from current Tagify values (store paths as a Set)
         state.selectedPaths = new Set(activeTagify.value.map(v => v.value));
 
         const tree = $(config.jsTreeId).jstree(true);

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -345,16 +345,24 @@ function loadKeywordsForConfig(config, response) {
     });
 
     // Initial sync: if the active input already has tags, select corresponding nodes
-    const activeTagify = getActiveTagifyForState(state);
-    if (activeTagify && activeTagify.value && activeTagify.value.length) {
-        var currentValues = activeTagify.value.map(v => v.value);
-        currentValues.forEach(function (val) {
-            var tree = $(config.jsTreeId).jstree(true);
-            if (!tree) return;
-            var node = findNodeByPath(tree, val);
-            if (node) tree.select_node(node.id);
+    $(config.jsTreeId).one("ready.jstree", function () {
+        const activeTagify = getActiveTagifyForState(state);
+        if (!activeTagify || !activeTagify.value || !activeTagify.value.length) return;
+
+        state.selectedPaths = new Set(activeTagify.value.map(v => v.value));
+
+        const tree = $(config.jsTreeId).jstree(true);
+        if (!tree) return;
+
+        activeTagify.value.forEach(function (tag) {
+            const node = findNodeByPath(tree, tag.value);
+            if (node) {
+                tree.select_node(node.id);
+            }
         });
-    }
+
+        updateSelectedKeywordsList(config.selectedListId || config.selectedKeywordsListId, state);
+    });
 }
 
 /** Returns the shared state key for a thesaurus config. */

--- a/js/thesauri.js
+++ b/js/thesauri.js
@@ -1097,6 +1097,7 @@ $(document).ready(function () {
             var thesaurusKeywordstagify = new Tagify(input, {
                 whitelist: state.whitelist,
                 enforceWhitelist: false,
+                delimiters: null,
                 placeholder: translations?.keywords?.thesaurus?.label || 'Thesaurus keywords',
                 dropdown: {
                     maxItems: 50,
@@ -1107,6 +1108,7 @@ $(document).ready(function () {
                 editTags: false
             });
             input._tagify = thesaurusKeywordstagify;
+            input.tagify = thesaurusKeywordstagify;
             state.tagify = thesaurusKeywordstagify;
             state.tagifyInstances.add(thesaurusKeywordstagify);
 

--- a/tests/js/mappingXmlToInputFields.module.test.js
+++ b/tests/js/mappingXmlToInputFields.module.test.js
@@ -700,4 +700,150 @@ describe('mappingXmlToInputFields module coverage', () => {
             expect(mappingModule.getTagifyInstance(element)).toBe(mockTagify);
         });
     });
+
+    describe('processKeywords', () => {
+        const resolver = (prefix) => prefix === 'ns' ? 'http://datacite.org/schema/kernel-4' : null;
+
+        test('routes free keywords to the free keyword field', () => {
+            document.body.innerHTML = `
+            <input id="input-freekeyword">
+        `;
+
+            const freeTagify = {
+                removeAllTags: jest.fn(),
+                addTags: jest.fn()
+            };
+
+            document.querySelector('#input-freekeyword')._tagify = freeTagify;
+
+            const xmlDoc = new DOMParser().parseFromString(`
+            <ns:resource xmlns:ns="http://datacite.org/schema/kernel-4">
+                <ns:subjects>
+                    <ns:subject>Test Keyword</ns:subject>
+                </ns:subjects>
+            </ns:resource>
+        `, 'text/xml');
+
+            mappingModule.processKeywords(xmlDoc, resolver);
+
+            expect(freeTagify.removeAllTags).toHaveBeenCalled();
+            expect(freeTagify.addTags).toHaveBeenCalledWith([
+                expect.objectContaining({ value: 'Test Keyword' })
+            ]);
+        });
+
+        test('routes MSL keywords to the MSL keyword field', () => {
+            document.body.innerHTML = `
+            <input id="input-mslkeyword">
+        `;
+
+            const mslTagify = {
+                removeAllTags: jest.fn(),
+                addTags: jest.fn()
+            };
+
+            document.querySelector('#input-mslkeyword')._tagify = mslTagify;
+
+            const xmlDoc = new DOMParser().parseFromString(`
+            <ns:resource xmlns:ns="http://datacite.org/schema/kernel-4">
+                <ns:subjects>
+                    <ns:subject schemeURI="https://epos-msl.uu.nl/voc/laboratories/123">msl Keyword</ns:subject>
+                </ns:subjects>
+            </ns:resource>
+        `, 'text/xml');
+
+            mappingModule.processKeywords(xmlDoc, resolver);
+
+            expect(mslTagify.removeAllTags).toHaveBeenCalled();
+            expect(mslTagify.addTags).toHaveBeenCalledWith([
+                expect.objectContaining({ value: 'msl Keyword' })
+            ]);
+        });
+
+        test('routes GCMD science keywords to the science keyword field', () => {
+            document.body.innerHTML = `
+            <input id="input-sciencekeyword">
+        `;
+
+            const scienceTagify = {
+                removeAllTags: jest.fn(),
+                addTags: jest.fn()
+            };
+
+            document.querySelector('#input-sciencekeyword')._tagify = scienceTagify;
+
+            const xmlDoc = new DOMParser().parseFromString(`
+            <ns:resource xmlns:ns="http://datacite.org/schema/kernel-4">
+                <ns:subjects>
+                    <ns:subject schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords">Earth Science</ns:subject>
+                </ns:subjects>
+            </ns:resource>
+        `, 'text/xml');
+
+            mappingModule.processKeywords(xmlDoc, resolver);
+
+            expect(scienceTagify.removeAllTags).toHaveBeenCalled();
+            expect(scienceTagify.addTags).toHaveBeenCalledWith([
+                expect.objectContaining({ value: 'Earth Science' })
+            ]);
+        });
+
+        test('routes chronostrat keywords to the chronostratigraphy field', () => {
+            document.body.innerHTML = `
+            <input id="input-chronostratigraphy">
+        `;
+
+            const chronostratTagify = {
+                removeAllTags: jest.fn(),
+                addTags: jest.fn()
+            };
+
+            document.querySelector('#input-chronostratigraphy')._tagify = chronostratTagify;
+
+            const xmlDoc = new DOMParser().parseFromString(`
+            <ns:resource xmlns:ns="http://datacite.org/schema/kernel-4">
+                <ns:subjects>
+                    <ns:subject schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020">one > two > chronostratigraphy</ns:subject>
+                </ns:subjects>
+            </ns:resource>
+        `, 'text/xml');
+
+            mappingModule.processKeywords(xmlDoc, resolver);
+
+            expect(chronostratTagify.removeAllTags).toHaveBeenCalled();
+            expect(chronostratTagify.addTags).toHaveBeenCalledWith([
+                expect.objectContaining({ value: 'one > two > chronostratigraphy' })
+            ]);
+        });
+
+        test('ignores keywords when the target field is not available', () => {
+            document.body.innerHTML = `
+            <input id="input-freekeyword">
+        `;
+
+            const freeTagify = {
+                removeAllTags: jest.fn(),
+                addTags: jest.fn()
+            };
+
+            document.querySelector('#input-freekeyword')._tagify = freeTagify;
+
+            const xmlDoc = new DOMParser().parseFromString(`
+            <ns:resource xmlns:ns="http://datacite.org/schema/kernel-4">
+                <ns:subjects>
+                    <ns:subject schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords">Earth Science</ns:subject>
+                    <ns:subject>Custom Keyword</ns:subject>
+                </ns:subjects>
+            </ns:resource>
+        `, 'text/xml');
+
+            mappingModule.processKeywords(xmlDoc, resolver);
+
+            expect(freeTagify.removeAllTags).toHaveBeenCalled();
+            expect(freeTagify.addTags).toHaveBeenCalledTimes(1);
+            expect(freeTagify.addTags).toHaveBeenCalledWith([
+                expect.objectContaining({ value: 'Custom Keyword' })
+            ]);
+        });
+    });
 });

--- a/tests/js/thesauri.test.js
+++ b/tests/js/thesauri.test.js
@@ -333,6 +333,28 @@ describe('thesauri.js', () => {
     expect(tree.get_selected()).toHaveLength(0);
   });
 
+  test('pre-populated Tagify values are synced to jsTree on ready after lazy loading', () => {
+    const input = document.getElementById('input-sciencekeyword');
+
+    // Simulate uploaded value before modal/tree is opened
+    input._tagify.addTags([{ value: 'Root > Child' }]);
+
+    // Tree not loaded yet
+    expect($('#jstree-sciencekeyword').jstree(true)).toBeUndefined();
+
+    // Open modal -> lazy loads thesaurus + initializes tree
+    openModal('#modal-sciencekeyword');
+
+    const tree = $('#jstree-sciencekeyword').jstree(true);
+    expect(tree).toBeDefined();
+
+    // Simulate jsTree ready event for the new ready-handler logic
+    $('#jstree-sciencekeyword').trigger('ready.jstree');
+
+    expect(tree.get_selected()).toEqual(['child']);
+    expect($('#selected-keywords-sciencekeyword li').text()).toContain('Root > Child');
+  });
+
   test('does not reload thesaurus data on subsequent modal opens', () => {
     openModal('#modal-sciencekeyword');
 


### PR DESCRIPTION
This PR fixes several issues around uploading and synchronising thesaurus keywords between Tagify inputs and the jsTree-based modals. It addresses and/or improves behaviour related to #850, #1019 and #879.


## Changes

- Made `processKeywords` route uploaded subjects to the correct Tagify instances so thesaurus groups upload independently.
- Adjusted initial jsTree sync to run on `ready` so pre‑populated Tagify values from upload are selected in the tree and shown in the "Selected Keywords" list.
- Fixed GEMET thesaurus selection.


## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
