### PR TITLE
Hotfix: declare the database password in the web containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,27 @@ This section outlines the automatic processes handled by the Docker environment 
 **2. `Dockerfile`** 
 - **Base Image:** Installs `php 8.5-apache` and essential dependencies, including the database client.
 - **Project Copy:** Copies the entire project directory into the container's root (`/var/www/html`), setting appropriate ownership for the standard Apache user (`www-data`). If you don't want something to be copied into container, include it into .dockerignore (performance might be affected)
-- **Multi-stage build:** The PHP web container -- built from Dockerfile.db -- uses multi stage build technique. Idea is the following: The final, "prod" container does not need everything created during the build process. Instead we want the final image to receive pre-compiled libraries authorised with a non-root user. 
+- **Multi-stage build:** The PHP web container -- built from `Dockerfile.db` -- uses a multi-stage build technique. The final `prod` image does not need everything created during the build process, so it only receives the required artifacts and runs as a non-root user. Setup is:
 
-Setup is the following:
-base  ──► dev  ──► builder  (COPY . . , prod deps)
-  │                   │
-  └──► prod ──────────┘ (COPY --from=builder)
+  ```mermaid
+  flowchart LR
+      base[base<br/>installs PHP deps and configures server]
+      dev[dev<br/>installs Node.js + Composer deps<br/>and copies project code]
+      builder[builder<br/>prepares production dependencies]
+      prod[prod<br/>non-root runtime image]
 
-Where:
+      base --> dev
+      dev --> builder
+      base --> prod
+      builder -->|COPY --from=builder| prod
+  ```
+
+  Where:
+  - `base` installs the PHP dependencies and configures the server.
+  - `dev` installs Node.js, Composer, and project dependencies; copies the code into the container; and runs the entrypoint script. This target is meant for full control in local development.
+  - `builder` minimizes the Composer installation for production artifacts.
+  - `prod` gets the pre-compiled dependencies, switches to a non-root user, and runs the entrypoint script. This is more fit for mission-critical tasks.
+
 
 - **Entrypoint:** Executes the `docker-entrypoint.sh` script.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
       # Database install routine
       INSTALL_ACTION: basic
       DB_INIT_MODE: drop_data
-
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-
+      ROOT_PASSWORD: ${ROOT_PASSWORD
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -25,8 +25,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-
-
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}
@@ -85,7 +84,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-            
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}
@@ -142,6 +141,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       # No install routine
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
@@ -199,6 +199,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       # No install routine
       INSTALL_ACTION: skip
       SMTP_HOST: ${SMTP_HOST}


### PR DESCRIPTION
Currently the problem is that the entrypoint script can't run, because it doesn't have the correct ROOT_PASSWORD

## Changes
Declare the password in the compose file to make this info available in the container internal environment 

## Notes for Reviewer
[Describe the steps needed to test this]

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
