### PR TITLE
Chore: named volumes in Docker compose.

### DIFF
--- a/docker-compose.gem.yml
+++ b/docker-compose.gem.yml
@@ -21,7 +21,7 @@ services:
       TZ: Europe/Berlin
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "6770", "-u", "root", "-p${ROOT_PASSWORD}"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -77,6 +77,8 @@ services:
       SHOW_SPATIAL_TEMPORAL_COVERAGE: "false"
       SHOW_RELATED_WORK: "true"
       INSTANCE_TITLE: "ELMO for ICGEM (open beta testing)"
+    depends_on:
+      - db
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pgrep apache2 > /dev/null || exit 1"]

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -71,6 +71,11 @@ services:
       - "traefik.http.middlewares.elmo-stripprefix.stripprefix.prefixes=/elmo"
       - "traefik.http.services.elmo-service.loadbalancer.server.port=80"
       - "traefik.docker.network=traefik"
+    volumes:
+      # Shared API responses cache: all variants see the same cached responses.
+      - api_cache_volume:/var/www/html/storage/cache
+      # Variant-specific drafts: keep each container's draft data isolated.
+      - web_drafts:/var/www/html/storage/drafts
 
   web-msl:
     build:
@@ -128,6 +133,9 @@ services:
       - "traefik.http.middlewares.elmo-msl-stripprefix.stripprefix.prefixes=/elmo-msl"
       - "traefik.http.services.elmo-msl-service.loadbalancer.server.port=80"
       - "traefik.docker.network=traefik"
+    volumes:
+      - api_cache_volume:/var/www/html/storage/cache
+      - web_msl_drafts:/var/www/html/storage/drafts
 
   web-gem:
     build:
@@ -186,6 +194,9 @@ services:
       - "traefik.http.middlewares.elmo-gem-stripprefix.stripprefix.prefixes=/elmo-gem"
       - "traefik.http.services.elmo-gem-service.loadbalancer.server.port=80"
       - "traefik.docker.network=traefik"
+    volumes:
+      - api_cache_volume:/var/www/html/storage/cache
+      - web_gem_drafts:/var/www/html/storage/drafts
 
   web-igsn:
     build:
@@ -245,9 +256,17 @@ services:
       - "traefik.http.middlewares.elmo-igsn-stripprefix.stripprefix.prefixes=/elmo-igsn"
       - "traefik.http.services.elmo-igsn-service.loadbalancer.server.port=80"
       - "traefik.docker.network=traefik"
+    volumes:
+      - api_cache_volume:/var/www/html/storage/cache
+      - web_igsn_drafts:/var/www/html/storage/drafts
 
 volumes:
   db_data:
+  api_cache_volume:
+  web_drafts:
+  web_msl_drafts:
+  web_gem_drafts:
+  web_igsn_drafts:
 
 networks:
   internal:

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -9,6 +9,12 @@ services:
       TZ: Europe/Berlin
     volumes:
       - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - internal


### PR DESCRIPTION
The Idea behind this is to reuse the cache from ERNIE across containers. If the dropdown options are selected in ERNIE for all ELMO versions, then why should every container re-fetch the options from ERNIE and store the same info separately. 

This PR also introduces named volumes for drafts. So if a container crashes, user will have at least access to the latest draft.

## Changes
Modified the compose files. Only for stage, I will modify the prod config, once the stage is ok.

## Notes for Reviewer
The propper testing is possible on stage only. There you will see all the ELMO [volumes](https://env.rz-vm182.gfz.de/portainer/#!/1/docker/volumes)

## Checklist
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog has been updated.
- [ ] My changes do not create new warnings in the test browser console.
- [ ] I have added unit tests that cover my code.
- [ ] All new and existing unit tests pass locally.
- [ ] All new and existing automated unit tests pass in the pull request.
- [ ] If applicable, Playwright tests have been updated and new tests added.
- [ ] All new and existing automated Playwright tests pass in the pull request.
- [ ] I ensured the changes meet accessibility guidelines.


## Known Issues
[What lower priority problems remain?]
