### PR TITLE
Fix: Role-less Contributor Handling

### DIFF
--- a/api/v2/controllers/DatasetController.php
+++ b/api/v2/controllers/DatasetController.php
@@ -899,12 +899,10 @@ class DatasetController
                         }
                     }
                 }
-                if (isset($person['Roles'])) {
-                    $rolesXml = $personXml->addChild('Roles');
-                    foreach ($person['Roles'] as $role) {
-                        $roleXml = $rolesXml->addChild('Role');
-                        $roleXml->addChild('name', htmlspecialchars($role['name'] ?? ''));
-                    }
+                $rolesXml = $personXml->addChild('Roles');
+                foreach ($this->getContributorRolesForExport($person['Roles'] ?? []) as $role) {
+                    $roleXml = $rolesXml->addChild('Role');
+                    $roleXml->addChild('name', htmlspecialchars($role['name'] ?? ''));
                 }
             }
         }
@@ -928,12 +926,10 @@ class DatasetController
                         }
                     }
                 }
-                if (isset($institution['Roles'])) {
-                    $rolesXml = $institutionXml->addChild('Roles');
-                    foreach ($institution['Roles'] as $role) {
-                        $roleXml = $rolesXml->addChild('Role');
-                        $roleXml->addChild('name', htmlspecialchars($role['name'] ?? ''));
-                    }
+                $rolesXml = $institutionXml->addChild('Roles');
+                foreach ($this->getContributorRolesForExport($institution['Roles'] ?? []) as $role) {
+                    $roleXml = $rolesXml->addChild('Role');
+                    $roleXml->addChild('name', htmlspecialchars($role['name'] ?? ''));
                 }
             }
         }
@@ -1106,6 +1102,21 @@ class DatasetController
         $stmt->close();
         // Return the XML as a string (additionally to saving it)
         return $xml->asXML();
+    }
+
+    /**
+     * Return explicit contributor roles or the DataCite-compatible draft fallback.
+     *
+     * The fallback is intentionally applied only while building export XML. It
+     * must not be written to contributor role relations because the user did not
+     * explicitly select it.
+     *
+     * @param array<int, array{name?: mixed}> $roles
+     * @return array<int, array{name: mixed}>
+     */
+    private function getContributorRolesForExport(array $roles): array
+    {
+        return $roles !== [] ? $roles : [['name' => 'Other']];
     }
 
     /**

--- a/save/formgroups/save_contributorinstitutions.php
+++ b/save/formgroups/save_contributorinstitutions.php
@@ -14,6 +14,9 @@ require_once __DIR__ . '/save_affiliations.php';
 function saveContributorInstitutions($connection, $postData, $resource_id)
 {
     $valid_roles = getValidRoles($connection);
+    $contributorRoles = isset($postData['cbOrganisationRoles']) && is_array($postData['cbOrganisationRoles'])
+        ? $postData['cbOrganisationRoles']
+        : [];
 
     // Validate only on submit
     $action = $postData['action'] ?? 'save_and_download';
@@ -21,11 +24,9 @@ function saveContributorInstitutions($connection, $postData, $resource_id)
     if (
         !isset(
         $postData['cbOrganisationName'],
-        $postData['cbOrganisationRoles'],
         $postData['OrganisationAffiliation']
     ) ||
         !is_array($postData['cbOrganisationName']) ||
-        !is_array($postData['cbOrganisationRoles']) ||
         !is_array($postData['OrganisationAffiliation'])
     ) {
         return true; // No data provided is valid
@@ -37,7 +38,7 @@ function saveContributorInstitutions($connection, $postData, $resource_id)
     for ($i = 0; $i < $len; $i++) {
         $entry = [
             'name' => $postData['cbOrganisationName'][$i] ?? '',
-            'roles' => $postData['cbOrganisationRoles'][$i] ?? '',
+            'roles' => $contributorRoles[$i] ?? [],
             'affiliation' => $postData['OrganisationAffiliation'][$i] ?? ''
         ];
 
@@ -54,8 +55,9 @@ function saveContributorInstitutions($connection, $postData, $resource_id)
             continue;
         }
 
-        // Skip if roles are empty (required field)
-        if (empty($entry['roles'])) {
+        // A name is required to persist the contributor identity. Roles may be
+        // omitted for draft downloads and receive an export-only fallback.
+        if (empty($entry['name'])) {
             continue;
         }
 

--- a/save/formgroups/save_contributorpersons.php
+++ b/save/formgroups/save_contributorpersons.php
@@ -15,6 +15,9 @@ function saveContributorPersons($connection, $postData, $resource_id)
 {
 
     $valid_roles = getValidRoles($connection);
+    $contributorRoles = isset($postData['cbPersonRoles']) && is_array($postData['cbPersonRoles'])
+        ? $postData['cbPersonRoles']
+        : [];
 
     // Validate only on submit
     $action = $postData['action'] ?? 'save_and_download';
@@ -25,12 +28,10 @@ function saveContributorPersons($connection, $postData, $resource_id)
         $postData['cbPersonLastname'],
         $postData['cbPersonFirstname'],
         $postData['cbORCID'],
-        $postData['cbAffiliation'],
-        $postData['cbPersonRoles']
+        $postData['cbAffiliation']
     ) ||
         !is_array($postData['cbPersonLastname']) || !is_array($postData['cbPersonFirstname']) ||
-        !is_array($postData['cbORCID']) || !is_array($postData['cbAffiliation']) ||
-        !is_array($postData['cbPersonRoles'])
+        !is_array($postData['cbORCID']) || !is_array($postData['cbAffiliation'])
     ) {
         return true; // No data provided is valid
     }
@@ -43,7 +44,7 @@ function saveContributorPersons($connection, $postData, $resource_id)
             'lastname' => $postData['cbPersonLastname'][$i] ?? '',
             'firstname' => $postData['cbPersonFirstname'][$i] ?? '',
             'orcid' => $postData['cbORCID'][$i] ?? '',
-            'roles' => $postData['cbPersonRoles'][$i] ?? ''
+            'roles' => $contributorRoles[$i] ?? []
         ];
         // Remove ORCID URL prefix if present (defense against frontend bypass)
         $entry['orcid'] = str_replace(['https://orcid.org/', 'http://orcid.org/'], '', $entry['orcid']);

--- a/tests/Issue1142ContributorExportTest.php
+++ b/tests/Issue1142ContributorExportTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+require_once __DIR__ . '/../api/v2/controllers/DatasetController.php';
+require_once __DIR__ . '/../save/formgroups/save_contributorpersons.php';
+require_once __DIR__ . '/../save/formgroups/save_contributorinstitutions.php';
+
+final class Issue1142ContributorExportTest extends DatabaseTestCase
+{
+    private \DatasetController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new \DatasetController();
+    }
+
+    public function testRolelessDraftContributorsAreExportedAsOtherWithAllMetadata(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.EXPORT', 'Roleless contributor export');
+
+        $personSaved = saveContributorPersons(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbPersonLastname' => ['Roleless'],
+                'cbPersonFirstname' => ['Person'],
+                'cbORCID' => ['0000-0002-1825-0097'],
+                'cbAffiliation' => ['[{"value":"Person University","rorId":"03yrm5c26"}]'],
+                'cbpRorIds' => ['03yrm5c26'],
+            ],
+            $resourceId
+        );
+        $institutionSaved = saveContributorInstitutions(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbOrganisationName' => ['Roleless Institute'],
+                'OrganisationAffiliation' => ['[{"value":"Institute Network","rorId":"04z8jg394"}]'],
+                'hiddenOrganisationRorId' => ['04z8jg394'],
+            ],
+            $resourceId
+        );
+
+        $this->assertTrue($personSaved);
+        $this->assertTrue($institutionSaved);
+
+        $resourceXml = $this->controller->getResourceAsXml($this->connection, $resourceId);
+        $resourceXPath = $this->xpath($resourceXml);
+
+        $this->assertSame(
+            'Other',
+            trim((string) $resourceXPath->evaluate('string(/Resource/Contributors/Persons/Person/Roles/Role/name)'))
+        );
+        $this->assertSame(
+            'Other',
+            trim((string) $resourceXPath->evaluate('string(/Resource/Contributors/Institutions/Institution/Roles/Role/name)'))
+        );
+
+        $dataCiteXml = $this->controller->transformResourceXmlString($resourceXml, 'datacite');
+        $dataCiteXPath = $this->dataCiteXPath($dataCiteXml);
+
+        $personQuery = '//dc:contributors/dc:contributor'
+            . '[@contributorType="Other" and dc:contributorName="Roleless, Person"]';
+        $institutionQuery = '//dc:contributors/dc:contributor'
+            . '[@contributorType="Other" and dc:contributorName="Roleless Institute"]';
+
+        $this->assertSame(1, $dataCiteXPath->query($personQuery)->length);
+        $this->assertSame(1, $dataCiteXPath->query($institutionQuery)->length);
+        $this->assertSame(
+            '0000-0002-1825-0097',
+            trim((string) $dataCiteXPath->evaluate("string({$personQuery}/dc:nameIdentifier[@nameIdentifierScheme='ORCID'])"))
+        );
+        $this->assertSame(
+            'Person University',
+            trim((string) $dataCiteXPath->evaluate("string({$personQuery}/dc:affiliation)"))
+        );
+        $this->assertSame(
+            'https://ror.org/03yrm5c26',
+            trim((string) $dataCiteXPath->evaluate("string({$personQuery}/dc:affiliation/@affiliationIdentifier)"))
+        );
+        $this->assertSame(
+            'Institute Network',
+            trim((string) $dataCiteXPath->evaluate("string({$institutionQuery}/dc:affiliation)"))
+        );
+        $this->assertSame(
+            'https://ror.org/04z8jg394',
+            trim((string) $dataCiteXPath->evaluate("string({$institutionQuery}/dc:affiliation/@affiliationIdentifier)"))
+        );
+    }
+
+    public function testExplicitContributorRolesAreExportedWithoutAdditionalFallback(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.EXPLICIT', 'Explicit contributor roles');
+
+        saveContributorPersons(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbPersonLastname' => ['Explicit'],
+                'cbPersonFirstname' => ['Researcher'],
+                'cbORCID' => [''],
+                'cbAffiliation' => [''],
+                'cbpRorIds' => [''],
+                'cbPersonRoles' => [['Researcher']],
+            ],
+            $resourceId
+        );
+        saveContributorInstitutions(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbOrganisationName' => ['Explicit Institute'],
+                'cbOrganisationRoles' => [['Hosting Institution']],
+                'OrganisationAffiliation' => [''],
+                'hiddenOrganisationRorId' => [''],
+            ],
+            $resourceId
+        );
+
+        $resourceXml = $this->controller->getResourceAsXml($this->connection, $resourceId);
+        $dataCiteXml = $this->controller->transformResourceXmlString($resourceXml, 'datacite');
+        $dataCiteXPath = $this->dataCiteXPath($dataCiteXml);
+
+        $this->assertSame(
+            1,
+            $dataCiteXPath->query('//dc:contributor[@contributorType="Researcher" and dc:contributorName="Explicit, Researcher"]')->length
+        );
+        $this->assertSame(
+            1,
+            $dataCiteXPath->query('//dc:contributor[@contributorType="HostingInstitution" and dc:contributorName="Explicit Institute"]')->length
+        );
+        $this->assertSame(0, $dataCiteXPath->query('//dc:contributor[@contributorType="Other"]')->length);
+    }
+
+    private function xpath(string $xml): \DOMXPath
+    {
+        $dom = new \DOMDocument();
+        $dom->loadXML($xml);
+
+        return new \DOMXPath($dom);
+    }
+
+    private function dataCiteXPath(string $xml): \DOMXPath
+    {
+        $xpath = $this->xpath($xml);
+        $xpath->registerNamespace('dc', 'http://datacite.org/schema/kernel-4');
+
+        return $xpath;
+    }
+}

--- a/tests/Issue1142ContributorSaveTest.php
+++ b/tests/Issue1142ContributorSaveTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+require_once __DIR__ . '/../save/formgroups/save_contributorpersons.php';
+require_once __DIR__ . '/../save/formgroups/save_contributorinstitutions.php';
+
+final class Issue1142ContributorSaveTest extends DatabaseTestCase
+{
+    public function testDraftPersonWithoutRoleIsSavedWithoutPersistedFallback(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.PERSON.DRAFT', 'Roleless draft person');
+
+        $saved = saveContributorPersons(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbPersonLastname' => ['Roleless'],
+                'cbPersonFirstname' => ['Person'],
+                'cbORCID' => [''],
+                'cbAffiliation' => [''],
+                'cbpRorIds' => [''],
+            ],
+            $resourceId
+        );
+
+        $this->assertTrue($saved);
+
+        $stmt = $this->connection->prepare(
+            'SELECT cp.contributor_person_id
+             FROM Contributor_Person cp
+             JOIN Resource_has_Contributor_Person rhcp
+               ON cp.contributor_person_id = rhcp.Contributor_Person_contributor_person_id
+             WHERE rhcp.Resource_resource_id = ? AND cp.familyname = ?'
+        );
+        $familyName = 'Roleless';
+        $stmt->bind_param('is', $resourceId, $familyName);
+        $stmt->execute();
+        $person = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        $this->assertIsArray($person, 'The roleless draft person must remain linked to the resource.');
+
+        $stmt = $this->connection->prepare(
+            'SELECT COUNT(*) AS role_count
+             FROM Contributor_Person_has_Role
+             WHERE Contributor_Person_contributor_person_id = ?'
+        );
+        $personId = (int) $person['contributor_person_id'];
+        $stmt->bind_param('i', $personId);
+        $stmt->execute();
+        $roleCount = (int) $stmt->get_result()->fetch_assoc()['role_count'];
+        $stmt->close();
+
+        $this->assertSame(0, $roleCount, 'The export fallback must not be persisted as a person role.');
+    }
+
+    public function testDraftInstitutionWithoutRoleIsSavedWithoutPersistedFallback(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.INSTITUTION.DRAFT', 'Roleless draft institution');
+
+        $saved = saveContributorInstitutions(
+            $this->connection,
+            [
+                'action' => 'save_and_download',
+                'cbOrganisationName' => ['Roleless Institute'],
+                'OrganisationAffiliation' => [''],
+                'hiddenOrganisationRorId' => [''],
+            ],
+            $resourceId
+        );
+
+        $this->assertTrue($saved);
+
+        $stmt = $this->connection->prepare(
+            'SELECT ci.contributor_institution_id
+             FROM Contributor_Institution ci
+             JOIN Resource_has_Contributor_Institution rhci
+               ON ci.contributor_institution_id = rhci.Contributor_Institution_contributor_institution_id
+             WHERE rhci.Resource_resource_id = ? AND ci.name = ?'
+        );
+        $institutionName = 'Roleless Institute';
+        $stmt->bind_param('is', $resourceId, $institutionName);
+        $stmt->execute();
+        $institution = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        $this->assertIsArray($institution, 'The roleless draft institution must remain linked to the resource.');
+
+        $stmt = $this->connection->prepare(
+            'SELECT COUNT(*) AS role_count
+             FROM Contributor_Institution_has_Role
+             WHERE Contributor_Institution_contributor_institution_id = ?'
+        );
+        $institutionId = (int) $institution['contributor_institution_id'];
+        $stmt->bind_param('i', $institutionId);
+        $stmt->execute();
+        $roleCount = (int) $stmt->get_result()->fetch_assoc()['role_count'];
+        $stmt->close();
+
+        $this->assertSame(0, $roleCount, 'The export fallback must not be persisted as an institution role.');
+    }
+
+    public function testSubmitRejectsPersonWithoutRole(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.PERSON.SUBMIT', 'Invalid submitted person');
+
+        $saved = saveContributorPersons(
+            $this->connection,
+            [
+                'action' => 'submit',
+                'cbPersonLastname' => ['NoRole'],
+                'cbPersonFirstname' => ['Person'],
+                'cbORCID' => [''],
+                'cbAffiliation' => [''],
+                'cbpRorIds' => [''],
+            ],
+            $resourceId
+        );
+
+        $this->assertFalse($saved);
+        $this->assertSame(0, $this->countRows('Contributor_Person'));
+        $this->assertSame(0, $this->countRows('Resource_has_Contributor_Person'));
+    }
+
+    public function testSubmitRejectsInstitutionWithoutRole(): void
+    {
+        $resourceId = $this->createResource('GFZ.TEST.ISSUE.1142.INSTITUTION.SUBMIT', 'Invalid submitted institution');
+
+        $saved = saveContributorInstitutions(
+            $this->connection,
+            [
+                'action' => 'submit',
+                'cbOrganisationName' => ['No Role Institute'],
+                'OrganisationAffiliation' => [''],
+                'hiddenOrganisationRorId' => [''],
+            ],
+            $resourceId
+        );
+
+        $this->assertFalse($saved);
+        $this->assertSame(0, $this->countRows('Contributor_Institution'));
+        $this->assertSame(0, $this->countRows('Resource_has_Contributor_Institution'));
+    }
+
+    private function countRows(string $table): int
+    {
+        $allowedTables = [
+            'Contributor_Person',
+            'Resource_has_Contributor_Person',
+            'Contributor_Institution',
+            'Resource_has_Contributor_Institution',
+        ];
+
+        if (!in_array($table, $allowedTables, true)) {
+            throw new \InvalidArgumentException("Unsupported test table: {$table}");
+        }
+
+        $result = $this->connection->query("SELECT COUNT(*) AS row_count FROM `{$table}`");
+
+        return (int) $result->fetch_assoc()['row_count'];
+    }
+}

--- a/tests/SaveContributorsTest.php
+++ b/tests/SaveContributorsTest.php
@@ -199,8 +199,8 @@ final class SaveContributorsTest extends DatabaseTestCase
     }
 
     /**
-     * Test saving incomplete contributor person and institution
-     * Verifies that incomplete records are not saved
+     * Test submitting incomplete contributor person and institution
+     * Verifies that incomplete records are not saved during strict submission
      *
      * @return void
      */
@@ -219,9 +219,10 @@ final class SaveContributorsTest extends DatabaseTestCase
         $resource_id = saveResourceInformationAndRights($this->connection, $resourceData);
 
         $postData = [
+            "action" => "submit",
             "cbPersonLastname" => [""],
             "cbPersonFirstname" => ["John"],
-            "cbORCID" => ["0000-0001-2345-6789"],
+            "cbORCID" => [""],
             "cbAffiliation" => ['[{"value":"Test University"}]'],
             "cbpRorIds" => ['[{"value":"https://ror.org/03yrm5c26"}]'],
             "cbPersonRoles" => [["Data Collector"]],

--- a/tests/playwright/flows/issue-1142-roleless-contributors.spec.ts
+++ b/tests/playwright/flows/issue-1142-roleless-contributors.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+import { XMLParser } from 'fast-xml-parser';
+import fs from 'node:fs';
+import { completeMinimalDatasetForm, navigateToHome } from '../utils';
+
+test.describe('Issue #1142 roleless contributor export', () => {
+  test.setTimeout(90_000);
+
+  test('exports draft persons and institutions with the Other fallback', async ({ page }) => {
+    await navigateToHome(page);
+    // The fixed footer can cover form controls in Playwright's default viewport.
+    await page.locator('footer.fixed-bottom').evaluate((footer) => footer.classList.remove('fixed-bottom'));
+    await completeMinimalDatasetForm(page);
+
+    const personRow = page.locator('[contributor-person-row]').first();
+    await personRow.locator('input[name="cbPersonLastname[]"]').fill('Roleless');
+    await personRow.locator('input[name="cbPersonFirstname[]"]').fill('Person');
+    await addAffiliation(personRow, 'Person University');
+
+    const institutionRow = page.locator('[contributors-row]').first();
+    await institutionRow.locator('input[name="cbOrganisationName[]"]').fill('Roleless Institute');
+    await addAffiliation(institutionRow, 'Institute Network');
+
+    await expect(personRow.locator('input[name="cbPersonRoles[]"]')).toHaveValue('');
+    await expect(institutionRow.locator('input[name="cbOrganisationRoles[]"]')).toHaveValue('');
+
+    await page.locator('#button-form-save').click();
+    const saveAsModal = page.locator('#modal-saveas');
+    await expect(saveAsModal).toBeVisible();
+    await page.locator('#input-saveas-filename').fill('issue-1142-roleless-contributors');
+
+    await page.waitForTimeout(2200);
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+    const responsePromise = page.waitForResponse(
+      (response) => response.url().includes('save/save_data.php'),
+      { timeout: 30_000 },
+    );
+
+    await page.locator('#button-saveas-save').click();
+
+    const [download, response] = await Promise.all([downloadPromise, responsePromise]);
+    expect(response.status()).toBe(200);
+
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+
+    const xml = fs.readFileSync(downloadPath!, 'utf8');
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '',
+    });
+    const resource = extractDataCiteResource(parser.parse(xml));
+    const contributors = toArray(resource?.contributors?.contributor);
+
+    const person = contributors.find(
+      (contributor) => contributor.familyName === 'Roleless',
+    );
+    const institution = contributors.find(
+      (contributor) => textOf(contributor.contributorName) === 'Roleless Institute',
+    );
+
+    expect(person, `Expected roleless person in ${JSON.stringify(contributors)}`).toBeTruthy();
+    expect(textOf(person.contributorName)).toBe('Roleless, Person');
+    expect(person.givenName).toBe('Person');
+    expect(person.contributorType).toBe('Other');
+    expect(textOf(person.affiliation)).toBe('Person University');
+
+    expect(institution, `Expected roleless institution in ${JSON.stringify(contributors)}`).toBeTruthy();
+    expect(institution.contributorType).toBe('Other');
+    expect(textOf(institution.affiliation)).toBe('Institute Network');
+  });
+});
+
+async function addAffiliation(row: import('@playwright/test').Locator, value: string): Promise<void> {
+  const tagInput = row.locator('.tagify__input[title^="Affiliation"]');
+  await expect(tagInput).toBeVisible();
+  await tagInput.click();
+  await tagInput.fill(value);
+  await tagInput.press('Enter');
+}
+
+function extractDataCiteResource(parsedXml: Record<string, any>): Record<string, any> | null {
+  const envelope = parsedXml.envelope
+    ?? Object.entries(parsedXml).find(([key]) => key.endsWith(':envelope'))?.[1];
+
+  if (!envelope || typeof envelope !== 'object') {
+    return null;
+  }
+
+  return envelope.resource
+    ?? Object.entries(envelope).find(([key]) => key.endsWith(':resource'))?.[1]
+    ?? null;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+}
+
+function textOf(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value && typeof value === 'object' && '#text' in value) {
+    return String((value as Record<string, unknown>)['#text']);
+  }
+
+  return '';
+}


### PR DESCRIPTION
This pull request addresses the handling of contributors without explicit roles in draft resources, ensuring that a DataCite-compatible fallback role ("Other") is only applied during export and never persisted to the database. It also introduces comprehensive tests to verify the correct behavior for both draft and submitted resources. The changes improve data integrity, maintain standards compliance, and clarify validation logic for contributor roles.

## Changes
### Contributor Role Handling and Export Logic
- Added the `getContributorRolesForExport` method in `DatasetController.php` to ensure that if a contributor (person or institution) has no explicit roles, the fallback role "Other" is used only during XML export and not persisted to the database.
- Updated the XML export logic for contributors to always use the new fallback method, ensuring consistent export behavior for roleless contributors. [[1]](diffhunk://#diff-8ce425ba8915b418472e33d4e7654da9d12e999c54dc1b10452af9f7fe7de734L902-L910) [[2]](diffhunk://#diff-8ce425ba8915b418472e33d4e7654da9d12e999c54dc1b10452af9f7fe7de734L931-L939)

### Form Data Validation and Persistence
- Modified `save_contributorpersons.php` and `save_contributorinstitutions.php` to allow saving draft contributors without roles (for download/export), but to require roles for submission. The fallback is not persisted; only explicit roles are stored. [[1]](diffhunk://#diff-d4b9e16626721eede93f515c97aeaf061c3be78fe22add7ce92df7b68878d80aR18-R20) [[2]](diffhunk://#diff-d4b9e16626721eede93f515c97aeaf061c3be78fe22add7ce92df7b68878d80aL28-R34) [[3]](diffhunk://#diff-d4b9e16626721eede93f515c97aeaf061c3be78fe22add7ce92df7b68878d80aL46-R47) [[4]](diffhunk://#diff-19d7a921103a5726b735c2a0b3a6f3f02b35abdc45ed42a84dcc280dd653a083R17-L28) [[5]](diffhunk://#diff-19d7a921103a5726b735c2a0b3a6f3f02b35abdc45ed42a84dcc280dd653a083L40-R41) [[6]](diffhunk://#diff-19d7a921103a5726b735c2a0b3a6f3f02b35abdc45ed42a84dcc280dd653a083L57-R60)

### Testing and Verification
- Added `Issue1142ContributorExportTest.php` to verify that roleless draft contributors are exported with the "Other" role and that explicit roles are exported as provided, without fallback.
- Added `Issue1142ContributorSaveTest.php` to ensure roleless draft contributors are not persisted with the fallback role and that submissions without roles are rejected.
- Updated `SaveContributorsTest.php` to clarify test intent and ensure strict validation on submission, not on draft save. [[1]](diffhunk://#diff-378ed67915b7c7392bce0a70cb9e5447b60fc0183456008d62cc4631a1d1897bL202-R203) [[2]](diffhunk://#diff-378ed67915b7c7392bce0a70cb9e5447b60fc0183456008d62cc4631a1d1897bR222-R225)

## Notes for Reviewer
None.

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None.
