### PR TITLE
Fix: Preserve URI-only Funding Awards at Saving

### DIFF
--- a/api/v2/controllers/DatasetController.php
+++ b/api/v2/controllers/DatasetController.php
@@ -1198,6 +1198,7 @@ class DatasetController
 
         if ($format === 'datacite') {
             $newXml = $this->stripEmptyDataciteElements($newXml);
+            $newXml = $this->restoreDataCiteAwardUrisWithoutNumbers($newXml, $sourceXmlString);
             $newXml = $this->restoreDataCiteDateOnlyCoverageDates($newXml, $sourceXmlString);
         }
 
@@ -1350,6 +1351,84 @@ class DatasetController
         }
 
         return null;
+    }
+
+    /**
+     * Restores Award URIs that the generated XSLT omits when no grant number exists.
+     *
+     * DataCite represents awardURI as an attribute of awardNumber. The schema permits
+     * awardNumber to have empty string content, but the generated XSLT only creates the
+     * element when the source contains a non-empty grantnumber.
+     *
+     * @param string $dataciteXml Transformed DataCite XML.
+     * @param string $sourceXml Source resource XML used for the transformation.
+     * @return string DataCite XML with URI-only award numbers preserved.
+     */
+    private function restoreDataCiteAwardUrisWithoutNumbers(string $dataciteXml, string $sourceXml): string
+    {
+        $sourceDom = new DOMDocument();
+        if (!$sourceDom->loadXML($sourceXml)) {
+            return $dataciteXml;
+        }
+
+        $sourceXPath = new DOMXPath($sourceDom);
+        $sourceReferences = $sourceXPath->query(
+            '/*[local-name()=\'Resource\']/*[local-name()=\'FundingReferences\']/*[local-name()=\'FundingReference\']'
+        );
+        if ($sourceReferences === false || $sourceReferences->length === 0) {
+            return $dataciteXml;
+        }
+
+        $dom = new DOMDocument();
+        $dom->formatOutput = true;
+        if (!$dom->loadXML($dataciteXml)) {
+            return $dataciteXml;
+        }
+
+        $ns = 'http://datacite.org/schema/kernel-4';
+        $xpath = new DOMXPath($dom);
+        $xpath->registerNamespace('dc', $ns);
+        $targetReferences = $xpath->query('//dc:fundingReferences/dc:fundingReference');
+        if ($targetReferences === false) {
+            return $dataciteXml;
+        }
+
+        foreach ($sourceReferences as $index => $sourceReference) {
+            $awardUri = trim((string) $sourceXPath->evaluate(
+                'string(*[local-name()=\'awarduri\'][1])',
+                $sourceReference
+            ));
+            $grantNumber = trim((string) $sourceXPath->evaluate(
+                'string(*[local-name()=\'grantnumber\'][1])',
+                $sourceReference
+            ));
+
+            if ($awardUri === '' || $grantNumber !== '') {
+                continue;
+            }
+
+            $targetReference = $targetReferences->item($index);
+            if (!$targetReference instanceof DOMElement) {
+                continue;
+            }
+
+            $existingAwardNumber = $xpath->query('dc:awardNumber', $targetReference)->item(0);
+            if ($existingAwardNumber instanceof DOMElement) {
+                continue;
+            }
+
+            $awardNumber = $dom->createElementNS($ns, 'awardNumber');
+            $awardNumber->setAttribute('awardURI', $awardUri);
+
+            $awardTitle = $xpath->query('dc:awardTitle', $targetReference)->item(0);
+            if ($awardTitle instanceof DOMNode) {
+                $targetReference->insertBefore($awardNumber, $awardTitle);
+            } else {
+                $targetReference->appendChild($awardNumber);
+            }
+        }
+
+        return $dom->saveXML();
     }
 
     /**

--- a/save/formgroups/save_fundingreferences.php
+++ b/save/formgroups/save_fundingreferences.php
@@ -72,10 +72,6 @@ function saveFundingReferenceEntry($connection, $entry, $resource_id)
         return true;
     }
 
-    if ($funder === '') {
-        return false;
-    }
-
     [$funderIdString, $funderIdType] = prepareFunderIdDetails($funderId, $entry['funderIdTyp'] ?? 'crossref');
     $awardUri = $awardUri !== '' ? $awardUri : null;
     $grantNumber = $grantNumber !== '' ? $grantNumber : null;

--- a/tests/IssueRegressionDatasetExportTest.php
+++ b/tests/IssueRegressionDatasetExportTest.php
@@ -16,6 +16,92 @@ final class IssueRegressionDatasetExportTest extends DatabaseTestCase
         $this->controller = new \DatasetController();
     }
 
+    public function testDataCiteTransformPreservesAwardUriWithoutGrantNumberForIssue1147(): void
+    {
+        $sourceXml = $this->resourceXmlWithCoverage(fundingReferences: <<<'XML'
+<FundingReferences>
+    <FundingReference>
+        <funder>Example Foundation</funder>
+        <awarduri>https://example.org/award?x=1&amp;y=2</awarduri>
+    </FundingReference>
+</FundingReferences>
+XML);
+
+        $dataciteXml = $this->controller->transformResourceXmlString($sourceXml, 'datacite');
+        $xpath = $this->dataCiteXPath($dataciteXml);
+        $awardNumbers = $xpath->query(
+            '//dc:fundingReference[dc:funderName = \'Example Foundation\']/dc:awardNumber'
+        );
+
+        $this->assertSame(1, $awardNumbers->length);
+        $this->assertSame('', trim($awardNumbers->item(0)->textContent));
+        $this->assertSame(
+            'https://example.org/award?x=1&y=2',
+            $awardNumbers->item(0)->getAttribute('awardURI')
+        );
+        $this->assertDataCiteSchemaValid($dataciteXml);
+    }
+
+    public function testDataCiteTransformDoesNotDuplicateAwardNumberForIssue1147(): void
+    {
+        $sourceXml = $this->resourceXmlWithCoverage(fundingReferences: <<<'XML'
+<FundingReferences>
+    <FundingReference>
+        <funder>Numbered Foundation</funder>
+        <grantnumber>GRANT-1147</grantnumber>
+        <awarduri>https://example.org/award/1147</awarduri>
+    </FundingReference>
+</FundingReferences>
+XML);
+
+        $dataciteXml = $this->controller->transformResourceXmlString($sourceXml, 'datacite');
+        $xpath = $this->dataCiteXPath($dataciteXml);
+        $awardNumbers = $xpath->query(
+            '//dc:fundingReference[dc:funderName = \'Numbered Foundation\']/dc:awardNumber'
+        );
+
+        $this->assertSame(1, $awardNumbers->length);
+        $this->assertSame('GRANT-1147', trim($awardNumbers->item(0)->textContent));
+        $this->assertSame(
+            'https://example.org/award/1147',
+            $awardNumbers->item(0)->getAttribute('awardURI')
+        );
+    }
+
+    public function testDataCiteTransformKeepsAwardUrisAssignedToTheirFundingReferencesForIssue1147(): void
+    {
+        $sourceXml = $this->resourceXmlWithCoverage(fundingReferences: <<<'XML'
+<FundingReferences>
+    <FundingReference>
+        <funder>URI Only Foundation</funder>
+        <awarduri>https://example.org/uri-only</awarduri>
+    </FundingReference>
+    <FundingReference>
+        <funder>Numbered Foundation</funder>
+        <grantnumber>GRANT-2</grantnumber>
+        <grantname>Second Award</grantname>
+        <awarduri>https://example.org/numbered</awarduri>
+    </FundingReference>
+    <FundingReference>
+        <funder>Title Only Foundation</funder>
+        <grantname>Third Award</grantname>
+    </FundingReference>
+</FundingReferences>
+XML);
+
+        $dataciteXml = $this->controller->transformResourceXmlString($sourceXml, 'datacite');
+        $xpath = $this->dataCiteXPath($dataciteXml);
+
+        $this->assertFundingAward($xpath, 'URI Only Foundation', '', 'https://example.org/uri-only');
+        $this->assertFundingAward($xpath, 'Numbered Foundation', 'GRANT-2', 'https://example.org/numbered');
+        $this->assertSame(
+            0,
+            $xpath->query(
+                '//dc:fundingReference[dc:funderName = \'Title Only Foundation\']/dc:awardNumber'
+            )->length
+        );
+    }
+
     public function testDataCiteTransformOmitsEmptyCreatedDateForIssue929(): void
     {
         $dataciteXml = $this->controller->transformResourceXmlString(
@@ -115,10 +201,57 @@ final class IssueRegressionDatasetExportTest extends DatabaseTestCase
         return $xpath;
     }
 
+    private function assertFundingAward(
+        \DOMXPath $xpath,
+        string $funderName,
+        string $awardNumber,
+        string $awardUri
+    ): void {
+        $fundingReferences = $xpath->query('//dc:fundingReference');
+        $matchingAward = null;
+
+        foreach ($fundingReferences as $fundingReference) {
+            $name = $xpath->query('dc:funderName', $fundingReference)->item(0);
+            if ($name === null || trim($name->textContent) !== $funderName) {
+                continue;
+            }
+
+            $matchingAward = $xpath->query('dc:awardNumber', $fundingReference)->item(0);
+            break;
+        }
+
+        $this->assertNotNull($matchingAward, "Missing awardNumber for {$funderName}.");
+        $this->assertSame($awardNumber, trim($matchingAward->textContent));
+        $this->assertSame($awardUri, $matchingAward->getAttribute('awardURI'));
+    }
+
+    private function assertDataCiteSchemaValid(string $xml): void
+    {
+        $dom = new \DOMDocument();
+        $this->assertTrue($dom->loadXML($xml));
+
+        $previousSetting = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            $isValid = $dom->schemaValidate(__DIR__ . '/../schemas/DataCite/DataCiteSchema47.xsd');
+            $errors = array_map(
+                static fn (\LibXMLError $error): string => trim($error->message),
+                libxml_get_errors()
+            );
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousSetting);
+        }
+
+        $this->assertTrue($isValid, implode(PHP_EOL, $errors));
+    }
+
     private function resourceXmlWithCoverage(
         ?string $dateCreated = '2026-01-01',
         string $dateStart = '2026-01-01',
-        ?string $dateEnd = '2026-12-31'
+        ?string $dateEnd = '2026-12-31',
+        string $fundingReferences = ''
     ): string {
         $dateCreatedElement = $dateCreated === null ? '' : "<dateCreated>{$dateCreated}</dateCreated>";
         $dateEndElement = $dateEnd === null ? '' : "<dateEnd>{$dateEnd}</dateEnd>";
@@ -149,6 +282,7 @@ final class IssueRegressionDatasetExportTest extends DatabaseTestCase
             {$dateEndElement}
         </SpatialTemporalCoverage>
     </SpatialTemporalCoverages>
+    {$fundingReferences}
 </Resource>
 XML;
     }

--- a/tests/SaveFundingreferencesTest.php
+++ b/tests/SaveFundingreferencesTest.php
@@ -161,6 +161,7 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
         $resource_id = saveResourceInformationAndRights($this->connection, $resourceData);
 
         $postData = [
+            "action" => "save_and_download",
             "funder" => [""],
             "funderId" => [""],
             "grantNummer" => ["INCOMPLETE123"],
@@ -170,14 +171,19 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
 
         $result = saveFundingReferences($this->connection, $postData, $resource_id);
 
-        $this->assertFalse($result, "Die Funktion sollte false zurückgeben.");
+        $this->assertTrue($result, 'Draft saving should accept an incomplete Funding Reference.');
 
-        // Check that no Funding Reference was saved
-        $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Funding_Reference");
+        $stmt = $this->connection->prepare(
+            'SELECT * FROM Funding_Reference WHERE grantnumber = ?'
+        );
+        $stmt->bind_param('s', $postData['grantNummer'][0]);
         $stmt->execute();
-        $count = $stmt->get_result()->fetch_assoc()['count'];
+        $fundingReference = $stmt->get_result()->fetch_assoc();
 
-        $this->assertEquals(0, $count, "Es sollten keine Funding References gespeichert worden sein.");
+        $this->assertNotNull($fundingReference);
+        $this->assertSame('', $fundingReference['funder']);
+        $this->assertSame($postData['grantName'][0], $fundingReference['grantname']);
+        $this->assertFundingReferenceLinked($resource_id, (int) $fundingReference['funding_reference_id']);
     }
 
     /**
@@ -188,6 +194,7 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
         $resource_id = $this->createResource('GFZ.TEST.AWARD.NO.FUNDER', 'Test Award URI Without Funder');
 
         $postData = [
+            'action' => 'save_and_download',
             'funder' => [''],
             'funderId' => [''],
             'grantNummer' => [''],
@@ -197,13 +204,88 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
 
         $result = saveFundingReferences($this->connection, $postData, $resource_id);
 
-        $this->assertFalse($result, 'Die Funktion sollte false zurückgeben.');
+        $this->assertTrue($result, 'Draft saving should accept an Award URI without a funder.');
 
-        $stmt = $this->connection->prepare('SELECT COUNT(*) as count FROM Funding_Reference');
+        $stmt = $this->connection->prepare('SELECT * FROM Funding_Reference WHERE awarduri = ?');
+        $stmt->bind_param('s', $postData['awardURI'][0]);
         $stmt->execute();
-        $count = $stmt->get_result()->fetch_assoc()['count'];
+        $fundingReference = $stmt->get_result()->fetch_assoc();
 
-        $this->assertEquals(0, $count, 'Es sollten keine Funding References gespeichert worden sein.');
+        $this->assertNotNull($fundingReference);
+        $this->assertSame('', $fundingReference['funder']);
+        $this->assertNull($fundingReference['grantnumber']);
+        $this->assertFundingReferenceLinked($resource_id, (int) $fundingReference['funding_reference_id']);
+    }
+
+    public function testSubmitRejectsGrantDetailsWithoutFunderBeforeAnyWrite(): void
+    {
+        $resource_id = $this->createResource('GFZ.TEST.SUBMIT.GRANT.NO.FUNDER', 'Submit Grant Without Funder');
+
+        $postData = [
+            'action' => 'submit',
+            'funder' => ['Valid Funder', ''],
+            'funderId' => ['', ''],
+            'grantNummer' => ['VALID-1', 'INVALID-2'],
+            'grantName' => ['Valid Grant', 'Missing Funder'],
+            'awardURI' => ['', '']
+        ];
+
+        $result = saveFundingReferences($this->connection, $postData, $resource_id);
+
+        $this->assertFalse($result);
+        $this->assertSame(
+            0,
+            $this->countFundingReferences(),
+            'Submit validation must reject all entries before the valid row can be written.'
+        );
+        $this->assertSame(0, $this->countFundingReferenceLinks($resource_id));
+    }
+
+    public function testSubmitRejectsAwardUriWithoutFunder(): void
+    {
+        $resource_id = $this->createResource('GFZ.TEST.SUBMIT.AWARD.NO.FUNDER', 'Submit Award URI Without Funder');
+
+        $postData = [
+            'action' => 'submit',
+            'funder' => [''],
+            'funderId' => [''],
+            'grantNummer' => [''],
+            'grantName' => [''],
+            'awardURI' => ['https://example.com/award']
+        ];
+
+        $result = saveFundingReferences($this->connection, $postData, $resource_id);
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->countFundingReferences());
+        $this->assertSame(0, $this->countFundingReferenceLinks($resource_id));
+    }
+
+    public function testSubmitAcceptsAwardUriWithoutGrantNumberWhenFunderExists(): void
+    {
+        $resource_id = $this->createResource('GFZ.TEST.SUBMIT.AWARD.WITH.FUNDER', 'Submit Award URI With Funder');
+
+        $postData = [
+            'action' => 'submit',
+            'funder' => ['Example Foundation'],
+            'funderId' => [''],
+            'grantNummer' => [''],
+            'grantName' => [''],
+            'awardURI' => ['https://example.com/award']
+        ];
+
+        $result = saveFundingReferences($this->connection, $postData, $resource_id);
+
+        $this->assertTrue($result);
+        $stmt = $this->connection->prepare('SELECT * FROM Funding_Reference WHERE funder = ?');
+        $stmt->bind_param('s', $postData['funder'][0]);
+        $stmt->execute();
+        $fundingReference = $stmt->get_result()->fetch_assoc();
+
+        $this->assertNotNull($fundingReference);
+        $this->assertNull($fundingReference['grantnumber']);
+        $this->assertSame($postData['awardURI'][0], $fundingReference['awarduri']);
+        $this->assertFundingReferenceLinked($resource_id, (int) $fundingReference['funding_reference_id']);
     }
 
     /**
@@ -224,6 +306,7 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
         $resource_id = saveResourceInformationAndRights($this->connection, $resourceData);
 
         $postData = [
+            "action" => "save_and_download",
             "funder" => ["Gordon and Betty Moore Foundation", "", "Ford Foundation"],
             "funderId" => ["https://doi.org/10.13039/100000936", "", ""],
             "grantNummer" => ["GBMF3859.01", "INCOMPLETE123", "FORD123"],
@@ -231,22 +314,24 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
             "awardURI" => ["https://example.com/award1", "", ""]
         ];
 
-        saveFundingReferences($this->connection, $postData, $resource_id);
+        $result = saveFundingReferences($this->connection, $postData, $resource_id);
 
-        // Check that only two Funding References were saved
+        $this->assertTrue($result);
+
+        // Check that every non-empty draft row was saved
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Funding_Reference");
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(2, $count, "Es sollten genau zwei Funding References gespeichert worden sein.");
+        $this->assertEquals(3, $count, "Es sollten genau drei Funding References gespeichert worden sein.");
 
-        // Check that only two relations to the resource were created
+        // Check that every saved row is linked to the resource
         $stmt = $this->connection->prepare("SELECT COUNT(*) as count FROM Resource_has_Funding_Reference WHERE Resource_resource_id = ?");
         $stmt->bind_param("i", $resource_id);
         $stmt->execute();
         $count = $stmt->get_result()->fetch_assoc()['count'];
 
-        $this->assertEquals(2, $count, "Es sollten genau zwei Verknüpfungen zwischen Resource und Funding Reference existieren.");
+        $this->assertEquals(3, $count, "Es sollten genau drei Verknüpfungen zwischen Resource und Funding Reference existieren.");
 
         // Check that the correct Funding References were saved
         $stmt = $this->connection->prepare("SELECT funder FROM Funding_Reference");
@@ -259,7 +344,7 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
 
         $this->assertContains("Gordon and Betty Moore Foundation", $savedFunders, "Die erste vollständige Funding Reference sollte gespeichert worden sein.");
         $this->assertContains("Ford Foundation", $savedFunders, "Die dritte vollständige Funding Reference sollte gespeichert worden sein.");
-        $this->assertNotContains("", $savedFunders, "Die unvollständige Funding Reference sollte nicht gespeichert worden sein.");
+        $this->assertContains("", $savedFunders, "Die unvollständige Draft Funding Reference sollte gespeichert worden sein.");
     }
 
     public function testSaveNoFundingReferenceData()
@@ -592,5 +677,36 @@ final class SaveFundingreferencesTest extends DatabaseTestCase
 
         $this->assertCount(1, $rows, 'Legacy row with SQL NULLs should be matched by form save with empty strings.');
         $this->assertEquals($legacyId, $rows[0]['funding_reference_id'], 'The pre-existing legacy row ID should be reused.');
+    }
+
+    private function countFundingReferences(): int
+    {
+        $result = $this->connection->query('SELECT COUNT(*) AS count FROM Funding_Reference');
+
+        return (int) $result->fetch_assoc()['count'];
+    }
+
+    private function countFundingReferenceLinks(int $resourceId): int
+    {
+        $stmt = $this->connection->prepare(
+            'SELECT COUNT(*) AS count FROM Resource_has_Funding_Reference WHERE Resource_resource_id = ?'
+        );
+        $stmt->bind_param('i', $resourceId);
+        $stmt->execute();
+
+        return (int) $stmt->get_result()->fetch_assoc()['count'];
+    }
+
+    private function assertFundingReferenceLinked(int $resourceId, int $fundingReferenceId): void
+    {
+        $stmt = $this->connection->prepare(
+            'SELECT COUNT(*) AS count
+             FROM Resource_has_Funding_Reference
+             WHERE Resource_resource_id = ? AND Funding_Reference_funding_reference_id = ?'
+        );
+        $stmt->bind_param('ii', $resourceId, $fundingReferenceId);
+        $stmt->execute();
+
+        $this->assertSame(1, (int) $stmt->get_result()->fetch_assoc()['count']);
     }
 }

--- a/tests/js/xmlRoundtripDataLoss.test.js
+++ b/tests/js/xmlRoundtripDataLoss.test.js
@@ -277,6 +277,40 @@ describe("funderIdentifierType import via XPath (regression for querySelector bu
 // ─── awardURI import verification ───────────────────────────────────────────
 
 describe("awardURI import from namespaced XML", () => {
+  test("awardURI is imported when awardNumber has no text content", () => {
+    document.body.innerHTML = `
+      <div id="group-fundingreference">
+        <div class="row">
+          <input name="funder[]" value="" />
+          <input name="funderId[]" value="" />
+          <input name="funderidtyp[]" value="" />
+          <input name="grantNummer[]" value="" />
+          <input name="grantName[]" value="" />
+          <input name="awardURI[]" value="" />
+        </div>
+      </div>
+      <button id="button-fundingreference-add"></button>`;
+
+    const $ = createJQuery();
+    const ctx = loadMappingModule({ $ });
+
+    const xml = buildNsPrefixXml(`
+      <ns:fundingReferences>
+        <ns:fundingReference>
+          <ns:funderName>URI Only Foundation</ns:funderName>
+          <ns:awardNumber awardURI="https://example.org/uri-only"/>
+        </ns:fundingReference>
+      </ns:fundingReferences>`);
+
+    const xmlDoc = new DOMParser().parseFromString(xml, "application/xml");
+    ctx.processFunders(xmlDoc, NS_RESOLVER);
+
+    expect(document.querySelector('input[name="grantNummer[]"]').value).toBe("");
+    expect(document.querySelector('input[name="awardURI[]"]').value).toBe(
+      "https://example.org/uri-only"
+    );
+  });
+
   test("awardURI is correctly imported via XPath getAttribute", () => {
     document.body.innerHTML = `
       <div id="group-fundingreference">

--- a/tests/playwright/flows/funding-reference-draft-save.spec.ts
+++ b/tests/playwright/flows/funding-reference-draft-save.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { XMLParser } from 'fast-xml-parser';
+import { completeMinimalDatasetForm, navigateToHome } from '../utils';
+
+const AWARD_URI = 'https://example.org/awards/issue-1147';
+
+test.describe('Issue 1147 funding-reference draft save', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToHome(page);
+    await completeMinimalDatasetForm(page);
+  });
+
+  test('Save & Download preserves an Award URI without funder or grant number', async ({ page }) => {
+    const funder = page.locator('#input-funder').first();
+    const grantNumber = page.locator('#input-grantnumber').first();
+    const awardUri = page.locator('#input-awarduri').first();
+
+    await awardUri.fill(AWARD_URI);
+    await expect(funder).toHaveValue('');
+    await expect(grantNumber).toHaveValue('');
+
+    await page.locator('#button-form-save').click();
+    const saveModal = page.locator('#modal-saveas');
+    await expect(saveModal).toBeVisible({ timeout: 10_000 });
+    await page.locator('#input-saveas-filename').fill('issue-1147-uri-only-award');
+
+    await page.waitForTimeout(2200);
+    const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+    await page.locator('#button-saveas-save').click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+
+    expect(downloadPath).not.toBeNull();
+    const xml = readFileSync(downloadPath!, 'utf8');
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '',
+      trimValues: false,
+    });
+    const parsed = parser.parse(xml);
+    const resource = parsed.envelope?.resource;
+    const fundingReference = resource?.fundingReferences?.fundingReference;
+
+    expect(fundingReference).toBeTruthy();
+    expect(fundingReference.funderName ?? '').toBe('');
+    expect(fundingReference.awardNumber?.awardURI).toBe(AWARD_URI);
+    expect(fundingReference.awardNumber?.['#text'] ?? '').toBe('');
+  });
+
+  test('Submit still requires a funder for an URI-only award', async ({ page }) => {
+    const funder = page.locator('#input-funder').first();
+    await page.locator('#input-awarduri').first().fill(AWARD_URI);
+
+    await page.locator('#button-form-submit').click();
+
+    await expect(funder).toHaveAttribute('required', 'required');
+    expect(await funder.evaluate((element: HTMLInputElement) => element.checkValidity())).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request introduces important improvements to the handling, transformation, and validation of funding references, especially regarding cases where an award URI exists without a grant number. It ensures that such cases are correctly preserved in DataCite XML exports, are accepted or rejected appropriately during draft and submit actions, and are thoroughly tested for both PHP and JavaScript layers.

## Changes
### DataCite XML Transformation and Export
- Added a new method `restoreDataCiteAwardUrisWithoutNumbers` in `DatasetController.php` to ensure that award URIs are preserved in the DataCite export even when no grant number is present. This addresses a previous issue where such URIs were omitted. (`api/v2/controllers/DatasetController.php`) [[1]](diffhunk://#diff-8ce425ba8915b418472e33d4e7654da9d12e999c54dc1b10452af9f7fe7de734R1201) [[2]](diffhunk://#diff-8ce425ba8915b418472e33d4e7654da9d12e999c54dc1b10452af9f7fe7de734R1356-R1433)

### Funding Reference Saving Logic
- Updated the funding reference saving logic to allow incomplete draft entries (such as those missing a funder or grant number) to be saved, while enforcing stricter validation on submit actions. This enables users to save drafts with partial information but requires complete data for final submission. (`save/formgroups/save_fundingreferences.php`)

### PHP Unit Tests for Funding References
- Expanded and improved test coverage for funding reference edge cases, including:
  - Ensuring award URIs without grant numbers are preserved in DataCite exports.
  - Verifying that incomplete funding references can be saved as drafts but are rejected on submit.
  - Testing proper linkage and storage of funding references in the database.
  - Adding utility assertions and helpers for more robust test validation. (`tests/SaveFundingreferencesTest.php`, `tests/IssueRegressionDatasetExportTest.php`) (F59af46eL72R72, [[1]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3L173-R186) [[2]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3L200-R288) [[3]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3R309-R334) [[4]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3L262-R347) [[5]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3R681-R711) [[6]](diffhunk://#diff-77dc229b2a2607fa69a6d6026916d01e37c3d439d5f1a9d0747509f4352d192aR19-R104) [[7]](diffhunk://#diff-77dc229b2a2607fa69a6d6026916d01e37c3d439d5f1a9d0747509f4352d192aR204-R254) [[8]](diffhunk://#diff-77dc229b2a2607fa69a6d6026916d01e37c3d439d5f1a9d0747509f4352d192aR285)

### JavaScript Import Logic
- Added a regression test to ensure that the front-end import logic correctly handles award URIs when the award number is empty, preventing data loss in the UI roundtrip. (`tests/js/xmlRoundtripDataLoss.test.js`)

### Test Utilities and Coverage
- Introduced new helper methods in test classes to count funding references, verify links, and assert correct DataCite schema validation, improving test reliability and maintainability. (`tests/SaveFundingreferencesTest.php`, `tests/IssueRegressionDatasetExportTest.php`) [[1]](diffhunk://#diff-53b4302fb370aece6c3abfe9cbacedf1c7da9361f2dc28a9ca4bc5852a194eb3R681-R711) [[2]](diffhunk://#diff-77dc229b2a2607fa69a6d6026916d01e37c3d439d5f1a9d0747509f4352d192aR204-R254)

## Notes for Reviewer
None.

## Checklist
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation has been updated.
- [x] If a new feature was added or a bug fixed, the changelog has been updated.
- [x] My changes do not create new warnings in the test browser console.
- [x] I have added unit tests that cover my code.
- [x] All new and existing unit tests pass locally.
- [x] All new and existing automated unit tests pass in the pull request.
- [x] If applicable, Playwright tests have been updated and new tests added.
- [x] All new and existing automated Playwright tests pass in the pull request.
- [x] I ensured the changes meet accessibility guidelines.


## Known Issues
None.
