### PR TITLE
Chore: implemented a better healthcheck for the mariadb containers

### DIFF
--- a/docker-compose.gem.yml
+++ b/docker-compose.gem.yml
@@ -90,6 +90,11 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  curl:
+    image: curlimages/curl:latest
+    network_mode: host
+    entrypoint: ["sleep", "infinity"]
+
 volumes:
   xml_data:
     driver: local

--- a/docker-compose.gem.yml
+++ b/docker-compose.gem.yml
@@ -21,11 +21,11 @@ services:
       TZ: Europe/Berlin
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "6770", "-u", "root", "-p${ROOT_PASSWORD}"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 3
     security_opt:
       - no-new-privileges:true
 

--- a/docker-compose.gem.yml
+++ b/docker-compose.gem.yml
@@ -84,6 +84,9 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+    depends_on:
+      db:
+        condition: service_healthy
     volumes:
       - xml_data:/var/www/html/xml
       - storage_data:/var/www/html/storage

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,12 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - internal
 
@@ -56,7 +62,8 @@ services:
       SHOW_SPATIAL_TEMPORAL_COVERAGE: ${SHOW_SPATIAL_TEMPORAL_COVERAGE:-true}
       SHOW_RELATED_WORK: ${SHOW_RELATED_WORK:-true}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal
@@ -81,7 +88,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
-      ROOT_PASSWORD: ${ROOT_PASSWORD
+      ROOT_PASSWORD: ${ROOT_PASSWORD}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}
@@ -111,7 +118,8 @@ services:
       SHOW_RELATED_WORK: ${SHOW_RELATED_WORK_MSL:-true}
       INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor 2.0"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -10,6 +10,12 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - internal
 

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -64,7 +64,8 @@ services:
       SHOW_SPATIAL_TEMPORAL_COVERAGE: "true"
       SHOW_RELATED_WORK: "true"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal
@@ -121,7 +122,8 @@ services:
       SHOW_RELATED_WORK: "true"
       INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor 2.0"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal
@@ -179,7 +181,8 @@ services:
       SHOW_RELATED_WORK: "true"
       INSTANCE_TITLE: "ELMO for ICGEM – Alpha Version"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal
@@ -238,7 +241,8 @@ services:
       INSTANCE_TITLE: "ELMO IGSN Edition – Alpha Version"
       DB_INIT_MODE: "keep_data"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,11 @@ services:
       TZ: Europe/Berlin
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 3
     security_opt:
       - no-new-privileges:true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,8 @@ services:
       API_BASE_URL: ${API_BASE_URL:-http://localhost:8080}
       LOCAL_DEVELOPMENT: "true"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       # Mount the entire project directory for live code changes.


### PR DESCRIPTION
Mariadb image implemented a healthcheck.sh, that does the job better then any custom healthcheck. This PR just implements theis healthceck for all the services except prod

## Changes
[What changes have you made?]

## Notes for Reviewer
[source](https://mariadb.com/docs/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/using-healthcheck-sh)

- rebuild containers
- check the db logs
- if it looks ok and you see healthcheck info, we are good

to do it run:

`docker-compose build --no-cache && docker-compose up -d`

## Checklist

### Branching Strategy:
If this is a hotfix: The branch was created from `main` and will be merged into `main`.
If this is a feature or documentation change: The branch was created from `dev` and will be merged into `dev`.
If this is a feature or documentation branch, I have pulled the latest changes from `main` into my branch.

### Code Quality
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] My changes do not create new warnings in the browser console.

### Documentation
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide ('./doc/help.html') has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation ('./api/v2/docs') has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog ('./doc/changelog.html') has been updated.

### Testing
- [ ] If needed, Playwright tests have been updated or added.
- [ ] If needed, unit tests have been updated or added.
- [ ] If needed, jest tests have been updated or added.


## Known Issues
[What lower priority problems remain?]
