### PR TITLE
Chore: File Name Conventions and CI check for them

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ELMO
 
-Thank you for your interest in contributing to ELMO! We welcome contributions of all kinds.
+Thank you for your interest in contributing to ELMO! We welcome contributions of all kinds. Before adding or renaming files, read the [project structure](../docs/project-structure.md) and [file-name conventions](../docs/file-naming-conventions.md).
 
 ## Branching Strategy
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -64,6 +66,11 @@ jobs:
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
+
+      - name: Check file-name conventions
+        env:
+          FILE_NAME_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: composer check:file-names -- --base="$FILE_NAME_BASE"
 
       - name: Install JS dependencies
         run: npm ci
@@ -179,7 +186,7 @@ jobs:
           PHP
 
       - name: Initialize database structure and lookup data
-        run: php -r "require 'install.php'; createDatabaseStructure(\$connection); insertLookupData(\$connection);"
+        run: php -r "require 'scripts/install.php'; createDatabaseStructure(\$connection); insertLookupData(\$connection);"
 
       - name: Start PHP built-in web server
         run: |

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
+        "check:file-names": "php scripts/check_file_names.php",
         "test": [
             "Composer\\Config::disableProcessTimeout",
             "phpunit"

--- a/docs/file-naming-conventions.md
+++ b/docs/file-naming-conventions.md
@@ -1,0 +1,56 @@
+# Dateinamen-Konventionen
+
+Diese Konvention gilt verbindlich für neue, verschobene, umbenannte und in einem Pull Request fachlich bearbeitete Dateien. Bestehende unberührte Dateien werden schrittweise migriert und müssen nicht gesammelt umbenannt werden.
+
+## Regeln
+
+| Dateityp | Konvention | Beispiel |
+| --- | --- | --- |
+| PHP-Klasse, Interface, Trait, Enum oder Testklasse | `PascalCase.php` und identisch zum primären Symbol | `DatasetController.php`, `FileNameConventionTest.php` |
+| Prozedurales PHP, Endpoint, Include oder CLI-Skript | `snake_case.php` | `send_feedback_mail.php`, `check_file_names.php` |
+| JavaScript-Modul | `camelCase.js` | `submitHandler.js` |
+| HTML und statische Browser-Assets | `kebab-case` | `apple-touch-icon.png` |
+| Playwright-/TypeScript-Spezifikation | `kebab-case.spec.ts` | `feedback-security.spec.ts` |
+| Verzeichnis | kleingeschrieben, bei neuen zusammengesetzten Namen `kebab-case` | `assets/icons`, `form-groups` |
+
+Ein einzelnes kleingeschriebenes Wort wie `index.php`, `logging.js` oder `favicon.svg` erfüllt die jeweilige Konvention ebenfalls.
+
+## Ausnahmen
+
+- Von Werkzeugen vorgegebene Namen, beispielsweise `composer.json`, `package-lock.json`, `.htaccess`, `Dockerfile.web` oder GitHub-Workflow-Dateien.
+- Drittanbieter-, generierte, Coverage-, Cache- und Laufzeitdateien.
+- `ci-router.php` bleibt während Issue #357 als bestehender Infrastruktur-Dateiname erhalten. Eine Umbenennung würde Aufrufkommandos und CI-Konfiguration ohne strukturellen Mehrwert verändern.
+- Bestehende, im jeweiligen Pull Request nicht bearbeitete Altdateien.
+
+Generische Sammelnamen wie `helper_functions.php` sollen vermieden werden. Neue Hilfslogik wird nach ihrem fachlichen Zweck benannt und im zuständigen Modul abgelegt.
+
+## Automatisierte Prüfung
+
+Geänderte Dateien im aktuellen Working Tree prüfen:
+
+```text
+composer check:file-names
+```
+
+Änderungen gegenüber einem Basis-Commit prüfen:
+
+```text
+composer check:file-names -- --base=<commit>
+```
+
+Alle versionierten Dateien prüfen, beispielsweise zur Ermittlung technischer Schulden:
+
+```text
+composer check:file-names -- --all
+```
+
+Der `--all`-Modus kann wegen bewusst noch nicht migrierter Altdateien fehlschlagen und ist vorerst kein verpflichtendes CI-Gate.
+
+## Groß-/Kleinschreibung unter Windows
+
+Eine reine Änderung der Groß-/Kleinschreibung muss zweistufig erfolgen, damit Git sie sowohl unter Windows als auch in Linux-Containern erkennt:
+
+```text
+git mv altername.php temp-name.php
+git mv temp-name.php AlterName.php
+```

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,63 @@
+# Projektstruktur
+
+Dieses Dokument beschreibt die nach Issue #357 eingeführten Verantwortungsgrenzen. Es ergänzt den [Dateinamen-Styleguide](file-naming-conventions.md).
+
+## Zentrale Verzeichnisse
+
+| Pfad | Verantwortung | HTTP-Zugriff |
+| --- | --- | --- |
+| `api/` | API-Frontcontroller, API-v2-Routen und temporärer API-v1-Tombstone | ja |
+| `endpoints/` | schlanke browserseitig aufgerufene PHP-Aktionen für Feedback, Submit und Event-Logging | ja |
+| `scripts/` | Installation, XML-Massengenerierung und Entwicklungsprüfungen | nein |
+| `assets/icons/` | Favicons, Apple-Touch-Icon und PWA-Icons | ja |
+| `logos/` | Marken- und Identifier-Logos | ja |
+| `includes/` | gemeinsam genutzte PHP-Hilfen ohne eigenen öffentlichen Endpunkt | indirekt |
+| `save/` | Speichern, Validieren und Persistieren von Formgruppen | indirekt |
+| `formgroups/` | serverseitig eingebundene HTML-Formulargruppen | ja |
+| `js/`, `css/`, `lang/` | Browserlogik, Styles und Übersetzungen | ja |
+| `doc/` | ausgelieferte Nutzerhilfe und Datenschutzseite | ja |
+| `docs/` | Entwickler-, Architektur- und Planungsdokumentation | nicht Teil des Produktionsartefakts |
+| `tests/` | PHPUnit-, Jest- und Playwright-Tests | nicht Teil des Produktionsartefakts |
+
+## Öffentliche Einstiege
+
+- `index.php` bleibt der Seiteneinstieg.
+- `header.php` bleibt vorerst das zentrale Root-Template.
+- `api/index.php` und `api/v2/index.php` bedienen die API-Routen.
+- `endpoints/send_feedback_mail.php`, `endpoints/send_xml_file.php` und `endpoints/log_page_event.php` sind die kanonischen Aktions-URLs.
+- Die früheren Root-URLs werden während der Kompatibilitätsphase intern umgeschrieben.
+
+## Nichtöffentliche CLI-Werkzeuge
+
+```text
+php scripts/install.php basic
+php scripts/install.php complete
+php scripts/generate_xml_files.php
+php scripts/check_file_names.php
+```
+
+Apache und der PHP-CI-Router antworten für `/scripts` und alle Unterpfade mit 404. Das schützt die Werkzeuge trotz des derzeit noch repositoryweiten Document-Roots.
+
+## Kompatibilitätsphase
+
+Folgende alte URLs bleiben vorübergehend erreichbar:
+
+- `/api.php` → `/api/deprecated_v1.php` mit HTTP 410,
+- `/doc/privacyPolicy.html` → `/doc/privacy-policy.html`,
+- `/send_feedback_mail.php` → `/endpoints/send_feedback_mail.php`,
+- `/send_xml_file.php` → `/endpoints/send_xml_file.php`,
+- `/log_page_event.php` → `/endpoints/log_page_event.php`,
+- ehemalige Root-URLs der Favicons/PWA-Icons → `/assets/icons/...`.
+
+Die Regeln sind sowohl in `.htaccess` als auch in `ci-router.php` abgebildet und durch Unit- sowie Browsertests abgesichert.
+
+## Bewusst vertagte Strukturarbeiten
+
+- Ein eigener `public/`-Document-Root, der Anwendungscode und Konfiguration grundsätzlich vom Webserver trennt.
+- PSR-4-Autoloading mit einem klaren `src/`-Namespace statt Composer-`classmap` über das gesamte Repository.
+- Klärung und mögliche Zusammenführung der unterschiedlichen Aufgaben von `doc/` und `docs/`.
+- Ein View-/Template-Verzeichnis für `header.php`, `footer.html` und `modals.html`.
+- Schrittweise Vereinheitlichung der historischen Formgruppen-Dateinamen.
+- Überprüfung weiterer Root-Konfigurations- und Settings-Dateien.
+
+Diese Punkte sollen als getrennte Issues geplant werden, damit die kompatible, begrenzte Migration aus #357 reviewbar bleibt.

--- a/scripts/check_file_names.php
+++ b/scripts/check_file_names.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Return a human-readable violation or null when the file name is valid or out of scope.
+ */
+function elmoFileNameViolation(string $path): ?string
+{
+    $normalizedPath = str_replace('\\', '/', trim($path));
+    if ($normalizedPath === '' || elmoFileNameCheckIsExcluded($normalizedPath)) {
+        return null;
+    }
+
+    if ($normalizedPath === 'ci-router.php') {
+        return null;
+    }
+
+    $extension = strtolower((string) pathinfo($normalizedPath, PATHINFO_EXTENSION));
+    $fileName = (string) pathinfo($normalizedPath, PATHINFO_FILENAME);
+
+    if ($extension === 'php') {
+        $isClassFile = false;
+        if (is_file($normalizedPath)) {
+            $contents = file_get_contents($normalizedPath);
+            $isClassFile = is_string($contents)
+                && preg_match('/\b(?:abstract\s+|final\s+)?(?:class|interface|trait|enum)\s+[A-Za-z_]/', $contents) === 1;
+        } else {
+            $isClassFile = preg_match('/Test$/', $fileName) === 1;
+        }
+
+        $pattern = $isClassFile
+            ? '/^[A-Z][A-Za-z0-9]*$/'
+            : '/^[a-z0-9]+(?:_[a-z0-9]+)*$/';
+
+        if (preg_match($pattern, $fileName) !== 1) {
+            return $isClassFile
+                ? 'PHP classes and tests must use PascalCase.php'
+                : 'procedural PHP files must use snake_case.php';
+        }
+
+        return null;
+    }
+
+    if ($extension === 'js') {
+        return preg_match('/^[a-z][A-Za-z0-9]*$/', $fileName) === 1
+            ? null
+            : 'JavaScript modules must use camelCase.js';
+    }
+
+    if ($extension === 'ts' && str_ends_with($fileName, '.spec')) {
+        $specName = substr($fileName, 0, -5);
+        return preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $specName) === 1
+            ? null
+            : 'Playwright specifications must use kebab-case.spec.ts';
+    }
+
+    if (in_array($extension, ['html', 'png', 'svg', 'ico'], true)) {
+        return preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $fileName) === 1
+            ? null
+            : 'HTML files and static browser assets must use kebab-case';
+    }
+
+    return null;
+}
+
+function elmoFileNameCheckIsExcluded(string $path): bool
+{
+    $excludedPrefixes = [
+        'vendor/',
+        'node_modules/',
+        'coverage/',
+        'coverage-',
+        'playwright-report/',
+        'test-results/',
+        'storage/',
+        'xml/',
+    ];
+
+    foreach ($excludedPrefixes as $prefix) {
+        if (str_starts_with($path, $prefix)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @param list<string> $arguments
+ * @return list<string>
+ */
+function elmoFilesToCheck(array $arguments): array
+{
+    if (in_array('--all', $arguments, true)) {
+        return elmoRunGitNameCommand('git ls-files');
+    }
+
+    foreach ($arguments as $argument) {
+        if (str_starts_with($argument, '--base=')) {
+            $base = substr($argument, strlen('--base='));
+            if ($base === '' || preg_match('/^[A-Za-z0-9._\/-]+$/', $base) !== 1) {
+                throw new InvalidArgumentException('Invalid --base revision.');
+            }
+
+            return elmoRunGitNameCommand(
+                'git diff --name-only --diff-filter=ACMR ' . escapeshellarg($base . '...HEAD')
+            );
+        }
+    }
+
+    $files = array_merge(
+        elmoRunGitNameCommand('git diff --name-only --diff-filter=ACMR HEAD'),
+        elmoRunGitNameCommand('git diff --cached --name-only --diff-filter=ACMR'),
+        elmoRunGitNameCommand('git ls-files --others --exclude-standard')
+    );
+
+    return array_values(array_unique($files));
+}
+
+/**
+ * @return list<string>
+ */
+function elmoRunGitNameCommand(string $command): array
+{
+    $output = [];
+    $exitCode = 0;
+    exec($command, $output, $exitCode);
+    if ($exitCode !== 0) {
+        throw new RuntimeException('Could not determine files with: ' . $command);
+    }
+
+    return array_values(array_filter(array_map('trim', $output), static fn (string $path): bool => $path !== ''));
+}
+
+/**
+ * @param list<string> $arguments
+ */
+function elmoRunFileNameCheck(array $arguments): int
+{
+    try {
+        $files = elmoFilesToCheck($arguments);
+    } catch (Throwable $exception) {
+        fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+        return 2;
+    }
+
+    $violations = [];
+    foreach ($files as $file) {
+        $violation = elmoFileNameViolation($file);
+        if ($violation !== null) {
+            $violations[$file] = $violation;
+        }
+    }
+
+    if ($violations === []) {
+        fwrite(STDOUT, sprintf("File-name check passed for %d file(s).%s", count($files), PHP_EOL));
+        return 0;
+    }
+
+    fwrite(STDERR, "File-name convention violations:" . PHP_EOL);
+    foreach ($violations as $file => $violation) {
+        fwrite(STDERR, sprintf("- %s: %s%s", $file, $violation, PHP_EOL));
+    }
+
+    return 1;
+}
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    $arguments = [];
+    foreach ($_SERVER['argv'] ?? [] as $argument) {
+        if (is_string($argument)) {
+            $arguments[] = $argument;
+        }
+    }
+
+    exit(elmoRunFileNameCheck($arguments));
+}

--- a/tests/CliScriptsTest.php
+++ b/tests/CliScriptsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+if (!defined('INCLUDED_FROM_TEST')) {
+    define('INCLUDED_FROM_TEST', true);
+}
+
+require_once dirname(__DIR__) . '/scripts/install.php';
+require_once dirname(__DIR__) . '/scripts/generate_xml_files.php';
+
+#[CoversNothing]
+final class CliScriptsTest extends TestCase
+{
+    #[DataProvider('validInstallActionProvider')]
+    public function testParsesSupportedInstallActions(string $action): void
+    {
+        self::assertSame($action, parseInstallationAction(['install.php', $action]));
+    }
+
+    /** @return array<string, array{0: string}> */
+    public static function validInstallActionProvider(): array
+    {
+        return [
+            'basic' => ['basic'],
+            'complete' => ['complete'],
+        ];
+    }
+
+    #[DataProvider('invalidInstallArgumentsProvider')]
+    public function testRejectsInvalidInstallActions(array $arguments): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('basic|complete');
+
+        parseInstallationAction($arguments);
+    }
+
+    /** @return array<string, array{0: list<string>}> */
+    public static function invalidInstallArgumentsProvider(): array
+    {
+        return [
+            'missing action' => [['install.php']],
+            'unknown action' => [['install.php', 'reset']],
+        ];
+    }
+
+    public function testXmlGenerationExitCodesReflectStatus(): void
+    {
+        self::assertSame(0, xmlGenerationExitCode(['status' => 'success']));
+        self::assertSame(1, xmlGenerationExitCode(['status' => 'warning']));
+        self::assertSame(1, xmlGenerationExitCode(['status' => 'error']));
+    }
+}


### PR DESCRIPTION
Introduce a new `scripts/check_file_names.php` CLI validator and wire it into Composer (`check:file-names`) and the PHPUnit GitHub workflow, including full-history checkout and PR-base diff support. Add developer docs for project structure and naming rules, and link them from CONTRIBUTING. Also add `CliScriptsTest` coverage for install/xml CLI helper behavior and update CI database init to load `scripts/install.php`.

## Changes
[What changes have you made?]

## Notes for Reviewer
[Describe the steps needed to test this]

## Checklist

### Branching Strategy:
If this is a hotfix: The branch was created from `main` and will be merged into `main`.
If this is a feature or documentation change: The branch was created from `dev` and will be merged into `dev`.
If this is a feature or documentation branch, I have pulled the latest changes from `main` into my branch.

### Code Quality
- [ ] My code follows the style guide.
- [ ] I have self-reviewed my code.
- [ ] I added comments for hard-to-understand code.
- [ ] My changes do not create new warnings in the browser console.

### Documentation
- [ ] If applicable, PHP code is documented using PHPDoc.
- [ ] If applicable, JavaScript code is documented using JSDoc.
- [ ] If needed, the ELMO Guide ('./doc/help.html') has been updated.
- [ ] If needed, the README has been updated.
- [ ] If needed, the API documentation ('./api/v2/docs') has been updated.
- [ ] If a new feature was added or a bug fixed, the changelog ('./doc/changelog.html') has been updated.

### Testing
- [ ] If needed, Playwright tests have been updated or added.
- [ ] If needed, unit tests have been updated or added.
- [ ] If needed, jest tests have been updated or added.


## Known Issues
[What lower priority problems remain?]
