### PR TITLE
Hotfix: STC validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the larger geographic latitude of a rectangle.
   - Data type: Floating-point number
-  - Occurrence: 0-1, becomes mandatory if Longitude Max is filled
+  - Occurrence: 0-1, becomes mandatory if any of the coordinate fields have been filled in
   - The corresponding field in the database where the value is stored is called: latitudeMax in the spatial_temporal_coverage table
   - Restrictions: Only positive and negative numbers in the value range from -90 to +90
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/geolocation/#northboundlatitude)
@@ -849,7 +849,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the geographic longitude of a single coordinate or the smaller geographic longitude of a rectangle.
   - Data type: Floating-point number
-  - Occurrence: 0-1
+  - Occurrence: 0-1 
   - The corresponding field in the database where the value is stored is called: longitudeMin in the spatial_temporal_coverage table
   - Restrictions: Only positive and negative numbers in the value range from -180 to +180
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/geolocation/#westboundlongitude)
@@ -859,7 +859,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the larger geographic longitude of a rectangle.
   - Data type: Floating-point number
-  - Occurrence: 0-1, becomes mandatory if Latitude Max is filled
+  - Occurrence: 0-1, becomes mandatory if any of the coordinate fields have been filled in
   - The corresponding field in the database where the value is stored is called: longitudeMax in the spatial_temporal_coverage table
   - Restrictions: Only positive and negative numbers in the value range from -180 to +180
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/geolocation/#eastboundlongitude)
@@ -869,7 +869,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
 
   This field contains a free-text explanation of the geographic and temporal context.
   - Data type: Free text
-  - Occurrence: 0-1
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: description in the spatial_temporal_coverage table
   - Restrictions: none
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/geolocation/#geolocationplace)
@@ -879,7 +879,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the starting date of the temporal classification of the dataset.
   - Data type: DATE
-  - Occurrence: 0-1 
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: dateStart in the spatial_temporal_coverage table
   - Restrictions: YYYY-MM-DD
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/appendices/appendix-1/dateType/#coverage)
@@ -889,7 +889,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the starting time.
   - Data type: TIME  
-  - Occurrence: 0-1, optional. If provided, both Start Time and End Time as well as Timezone become mandatory.
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: timeStart in the spatial_temporal_coverage table
   - Restrictions: hh:mm:ss
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/appendices/appendix-1/dateType/#coverage)
@@ -899,7 +899,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the ending date of the temporal classification of the dataset.
   - Data type: DATE
-  - Occurrence: 0-1
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: dateEnd in the spatial_temporal_coverage table
   - Restrictions: YYYY-MM-DD
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/appendices/appendix-1/dateType/#coverage)
@@ -909,7 +909,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the ending time.
   - Data type: TIME 
-  - Occurrence: 0-1, optional. If provided, both Start Time and End Time as well as Timezone become mandatory.
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: timeEnd in the spatial_temporal_coverage table
   - Restrictions: hh:mm:ss
   - [DataCite documentation](https://datacite-metadata-schema.readthedocs.io/en/4.7/appendices/appendix-1/dateType/#coverage)
@@ -919,7 +919,7 @@ In the ISO scheme: All field data are mapped to `<EX_Extent>`. Spatial data (coo
   
   This field contains the timezone of the start and end times specified. All possible timezones are regularly updated via the API using the getTimezones method if a CronJob is configured on the server. Important: The API key for timezonedb.com must be specified in the settings to enable automatic updates!
   - Data type: String
-  - Occurrence: 0-1, mandatory only when Start Time or End Time is provided.
+  - Occurrence: 0
   - The corresponding field in the database where the value is stored is called: timezone in the spatial_temporal_coverage table
   - Restrictions: Only values from the list are permitted
   - ISO documentation

--- a/doc/help.html
+++ b/doc/help.html
@@ -1004,17 +1004,16 @@ include_once "../settings.php";
                         <li><strong>Start Date:</strong> Date of the beginning of the temporal coverage of the
                             dataset. Can be selected via the date picker. Required field.</li>
                         <li><strong>Start Time:</strong> Time specification in format hh:mm:ss. Can be selected via
-                            the time picker. <strong>Optional.</strong></li>
+                            the time picker.</li>
                         <li><strong>End Date:</strong> Date of the end of the temporal coverage of the dataset. Can
                             be selected via the date picker. Required field.</li>
                         <li><strong>End Time:</strong> Time specification in format hh:mm:ss. Can be selected via
-                            the time picker. <strong>Optional.</strong></li>
+                            the time picker.</li>
                     </ul>
                 </div>
                 <div id="help-tsc-timezone">
                     <h4>Timezone</h4>
-                    Specifies the UTC-based time zone for start and end times.
-                    <strong>Only required if times are provided.</strong><br>
+                    Specifies the UTC-based time zone for start and end times.<br>
                     This field allows selection from all worldwide time zones to accurately represent the
                     temporal details of your data.
                 </div>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -111,7 +111,7 @@ services:
       SHOW_FREE_KEYWORDS: ${SHOW_FREE_KEYWORDS_MSL:-true}
       SHOW_SPATIAL_TEMPORAL_COVERAGE: ${SHOW_SPATIAL_TEMPORAL_COVERAGE_MSL:-true}
       SHOW_RELATED_WORK: ${SHOW_RELATED_WORK_MSL:-true}
-      INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor 2.0"
+      INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor"
     depends_on:
       - db
     restart: unless-stopped

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -113,7 +113,7 @@ services:
       SHOW_FREE_KEYWORDS: "true"
       SHOW_SPATIAL_TEMPORAL_COVERAGE: "true"
       SHOW_RELATED_WORK: "true"
-      INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor 2.0"
+      INSTANCE_TITLE: "ELMO MSL Edition – GFZ Metadata Editor"
     depends_on:
       - db
     restart: unless-stopped

--- a/header.php
+++ b/header.php
@@ -15,7 +15,7 @@ sort($langCodes);
 
 // Fallback for instance title if not defined in settings
 if (!isset($instanceTitle)) {
-    $instanceTitle = getenv('INSTANCE_TITLE') ?: 'ELMO – GFZ Metadata Editor 2.0';
+    $instanceTitle = getenv('INSTANCE_TITLE') ?: 'ELMO – GFZ Metadata Editor';
 }
 
 // Determine base href, taking reverse proxy prefixes into account

--- a/js/checkMandatoryFields.js
+++ b/js/checkMandatoryFields.js
@@ -189,8 +189,10 @@ function updateStcRequiredVisualCue(inputElement, isRequired) {
     input.toggleClass('border-danger', isRequired && value === '');
 
     if (isRequired) {
+        input.attr('required', 'required');
         input.attr('aria-required', 'true');
     } else {
+        input.removeAttr('required');
         input.removeAttr('aria-required');
     }
 

--- a/js/checkMandatoryFields.js
+++ b/js/checkMandatoryFields.js
@@ -214,27 +214,22 @@ function updateStcRowRequiredVisualCues(inputs) {
 }
 
 /**
- * Dynamically applies or removes the 'required' attribute to input fields in each row within #group-stc.
+ * Dynamically marks STC coordinate fields as required on submit.
  *
- * The function ensures:
- * - If all fields are empty, none will be required.
- * - If latMax or longMax is filled, latMin, longMin, latMax, longMax, description, and, outside ELMO-GEM, dateStart/dateEnd become required.
- * - If latMin, longMin, or description is filled, those fields and, outside ELMO-GEM, dateStart/dateEnd become required.
- * - If dateStart or dateEnd is filled, they along with latMin, longMin, and description become required.
- * - Time fields (timeStart, timeEnd) are always optional unless one of them is filled.
- * - If timeStart or timeEnd is filled, both time fields, dates, and timezone become required.
- * - Timezone is only required when time values are provided.
+ * Rules:
+ * - If latmin is filled, longmin becomes required.
+ * - If longmin is filled, latmin becomes required.
+ * - If latmax or longmax is filled, all four coordinate fields become required.
+ * - If all four fields are empty, no validation is applied.
  *
  * @function validateSpatialTemporalCoverageRequirements
  * @returns {void}
  */
 function validateSpatialTemporalCoverageRequirements() {
     var group = $('#group-stc');
-    var fields = ['latmin', 'latmax', 'longmin', 'longmax', 'description', 'datestart', 'timestart', 'dateend', 'timeend', 'timezone'];
+    var fields = ['latmin', 'latmax', 'longmin', 'longmax'];
     var allRows = group.find('[tsc-row]');
 
-    var isElmoGem = Boolean(window.ELMO_FEATURES && window.ELMO_FEATURES.showGGMsProperties);
-    // Process each row independently
     allRows.each(function () {
         var row = $(this);
         var inputs = {};
@@ -243,7 +238,8 @@ function validateSpatialTemporalCoverageRequirements() {
         // Store jQuery elements and their filled status
         fields.forEach(function (field) {
             inputs[field] = row.find('[id^="input-stc-' + field + '"]');
-            filled[field] = inputs[field].val() && inputs[field].val().trim() !== '';
+            filled[field] = String(inputs[field].val() || '').trim() !== '';
+
             inputs[field].removeAttr('required')
                 .removeAttr('aria-required')
                 .removeClass('js-required-on-submit stc-required-on-submit border-danger');
@@ -255,50 +251,23 @@ function validateSpatialTemporalCoverageRequirements() {
             return;
         }
 
-        // _______________________________________________________________________
-
-        // Bounding box dependencies -> dates required outside ELMO-GEM but time optional
+        // If any MAX field is filled, all four fields are required.
         if (filled.latmax || filled.longmax) {
-            var boundingBoxRequiredFields = ['latmin', 'longmin', 'latmax', 'longmax', 'description'];
+            fields.forEach(function (field) {
+                inputs[field].addClass('js-required-on-submit');
+            });
 
-            if (!isElmoGem) {
-                boundingBoxRequiredFields = boundingBoxRequiredFields.concat(['datestart', 'dateend']);
-            }
-
-            boundingBoxRequiredFields
-                .forEach(function (field) {
-                    inputs[field].addClass('js-required-on-submit');
-                });
+            updateStcRowRequiredVisualCues(inputs);
+            return;
         }
 
-        // If any of latmin/longmin/description is filled -> dates required outside ELMO-GEM, time optional
-        if (filled.latmin || filled.longmin || filled.description) {
-            var spatialRequiredFields = ['latmin', 'longmin', 'description'];
-
-            if (!isElmoGem) {
-                spatialRequiredFields = spatialRequiredFields.concat(['datestart', 'dateend']);
-            }
-
-            spatialRequiredFields
-                .forEach(function (field) {
-                    inputs[field].addClass('js-required-on-submit');
-                });
+        // Point rule: latmin <-> longmin
+        if (filled.latmin) {
+            inputs.longmin.addClass('js-required-on-submit');
         }
 
-        // If dates are provided -> ensure basic required fields, time optional
-        if (filled.datestart || filled.dateend) {
-            ['datestart', 'dateend', 'latmin', 'longmin', 'description']
-                .forEach(function (field) {
-                    inputs[field].addClass('js-required-on-submit');
-                });
-        }
-
-        // If any time value is provided in this row -> require both times, dates and timezone
-        if (filled.timestart || filled.timeend) {
-            ['timestart', 'timeend', 'datestart', 'dateend', 'latmin', 'longmin', 'description', 'timezone']
-                .forEach(function (field) {
-                    inputs[field].addClass('js-required-on-submit');
-                });
+        if (filled.longmin) {
+            inputs.latmin.addClass('js-required-on-submit');
         }
 
         updateStcRowRequiredVisualCues(inputs);

--- a/save/formgroups/save_spatialtemporalcoverage.php
+++ b/save/formgroups/save_spatialtemporalcoverage.php
@@ -22,7 +22,6 @@ function saveSpatialTemporalCoverage($connection, $postData, $resource_id)
     global $showGGMsProperties;
 
     $action = $postData['action'] ?? 'save_and_download';
-    $isElmoGem = !empty($showGGMsProperties);
 
     // If NO STC data provided at all, return early (it's optional)
     // Only skip if BOTH spatial and temporal fields are empty

--- a/save/formgroups/save_spatialtemporalcoverage.php
+++ b/save/formgroups/save_spatialtemporalcoverage.php
@@ -69,38 +69,14 @@ function saveSpatialTemporalCoverage($connection, $postData, $resource_id)
             }
 
             // Check required fields: latitudeMin and longitudeMin (0 is allowed, empty strings are not)
-            if ((trim($entry['latitudeMin'] ?? '') === '') || (trim($entry['longitudeMin'] ?? '') === '')) {
-                $allSuccessful = false;
-                continue;
-            }
-
-            if ($isElmoGem && trim($entry['description'] ?? '') === '') {
-                $allSuccessful = false;
-                continue;
-            }
-
             if (!validateSTCDependencies($entry)) {
                 $allSuccessful = false;
                 continue;
             }
 
-            // Outside ELMO-GEM, submitted STC rows with spatial data still need temporal coverage.
-            if (trim($entry['dateStart'] ?? '') === '') {
-                if (!$isElmoGem) {
-                    $allSuccessful = false;
-                    continue;
-                }
-            }
         } else {
-            // Even without submit, skip entries with incomplete coordinates
             $hasAnySpatial = (trim($entry['latitudeMin'] ?? '') !== '') || (trim($entry['latitudeMax'] ?? '') !== '')
                           || (trim($entry['longitudeMin'] ?? '') !== '') || (trim($entry['longitudeMax'] ?? '') !== '');
-            $hasBothRequired = (trim($entry['latitudeMin'] ?? '') !== '') && (trim($entry['longitudeMin'] ?? '') !== '');
-            if ($hasAnySpatial && !$hasBothRequired) {
-                $allSuccessful = false;
-                continue;
-            }
-            // Skip entries where all fields are effectively empty
             $hasAnyData = $hasAnySpatial
                        || (trim($entry['dateStart'] ?? '') !== '')
                        || (trim($entry['dateEnd'] ?? '') !== '')

--- a/save/validation.php
+++ b/save/validation.php
@@ -234,48 +234,30 @@ function normalizeTimeForComparison($timeValue)
  */
 function validateSTCDependencies($entry)
 {
-    $hasTimeStart = trim((string) ($entry['timeStart'] ?? '')) !== '';
-    $hasTimeEnd = trim((string) ($entry['timeEnd'] ?? '')) !== '';
+    $latMin  = trim((string)($entry['latitudeMin'] ?? ''));
+    $latMax  = trim((string)($entry['latitudeMax'] ?? ''));
+    $longMin = trim((string)($entry['longitudeMin'] ?? ''));
+    $longMax = trim((string)($entry['longitudeMax'] ?? ''));
 
-    // If a time value is given, a full date/time/zone set is required.
-    if (
-        ($hasTimeStart || $hasTimeEnd) &&
-        (
-            !$hasTimeStart ||
-            !$hasTimeEnd ||
-            trim((string) ($entry['dateStart'] ?? '')) === '' ||
-            trim((string) ($entry['dateEnd'] ?? '')) === '' ||
-            trim((string) ($entry['timezone'] ?? '')) === ''
-        )
-    ) {
-        error_log("[SAVE] STC validation failed: A complete date/time/zone set is required if a time value is provided. Entry: " . json_encode($entry));
+    $hasLatMin  = $latMin !== '';
+    $hasLatMax  = $latMax !== '';
+    $hasLongMin = $longMin !== '';
+    $hasLongMax = $longMax !== '';
+
+    if (!$hasLatMin && !$hasLatMax && !$hasLongMin && !$hasLongMax) {
+        return true;
+    }
+
+    if ($hasLatMax || $hasLongMax) {
+        return $hasLatMin && $hasLatMax && $hasLongMin && $hasLongMax;
+    }
+
+    if ($hasLatMin && !$hasLongMin) {
         return false;
     }
 
-    // If longitudeMax is given, latitudeMax must also be given and vice versa
-    if (
-        (!empty($entry['longitudeMax']) && empty($entry['latitudeMax'])) ||
-        (empty($entry['longitudeMax']) && !empty($entry['latitudeMax']))
-    ) {
-        error_log("[SAVE] STC validation failed: longitudeMax and latitudeMax must be provided together. Entry: " . json_encode($entry));
+    if ($hasLongMin && !$hasLatMin) {
         return false;
-    }
-
-    // If dates are equal and both times are present, end time must not be before start time
-    if (
-        !empty($entry['dateStart']) &&
-        !empty($entry['dateEnd']) &&
-        $entry['dateStart'] === $entry['dateEnd'] &&
-        !empty($entry['timeStart']) &&
-        !empty($entry['timeEnd'])
-    ) {
-        $timeStart = normalizeTimeForComparison((string) $entry['timeStart']);
-        $timeEnd = normalizeTimeForComparison((string) $entry['timeEnd']);
-
-        if ($timeStart !== null && $timeEnd !== null && $timeEnd < $timeStart) {
-            error_log("[SAVE] STC validation failed: End time cannot be before start time on the same day. Entry: " . json_encode($entry));
-            return false;
-        }
     }
 
     return true;

--- a/settings.elmo.php
+++ b/settings.elmo.php
@@ -199,7 +199,7 @@ if (isset($_GET['setting'])) {
 }
 
 // Instance title for header (can be overridden via environment variable)
-$instanceTitle = getenv('INSTANCE_TITLE') ?: 'ELMO – GFZ Metadata Editor 2.0';
+$instanceTitle = getenv('INSTANCE_TITLE') ?: 'ELMO – GFZ Metadata Editor';
 
 // Initialize logging
 function elmo_log($msg) {

--- a/tests/SaveSpatialTemporalCoverageTest.php
+++ b/tests/SaveSpatialTemporalCoverageTest.php
@@ -756,4 +756,89 @@ final class SaveSpatialTemporalCoverageTest extends DatabaseTestCase
         $this->assertEquals(0, (float)$retrievedStc["longitudeMin"], 'Zero longitudeMin should be saved as 0, not NULL');
         $this->assertEquals(0, (float)$retrievedStc["longitudeMax"], 'Zero longitudeMax should be saved as 0, not NULL');
     }
+    
+    /**
+     * Tests that saving fails when longitudeMax is set but the bounding box is incomplete.
+     * 
+     * This covers the scenario where one of the maximum coordinate values is provided
+     * without all four bounding box coordinates being present. The backend should
+     * reject incomplete bounding box definitions.
+     *
+     * @return void
+     */
+    public function testSaveFailsWhenLongitudeMaxIsGivenButBoundingBoxIsIncomplete(): void
+    {
+        $resourceData = [
+            "doi" => "10.5880/GFZ.TEST.INCOMPLETE.BBOX." . uniqid(),
+            "year" => 2026,
+            "dateCreated" => "2026-01-24",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Test Incomplete Bounding Box"],
+            "titleType" => [1]
+        ];
+        $resource_id = saveResourceInformationAndRights($this->connection, $resourceData);
+
+        $postData = [
+            "tscLatitudeMin"  => ["45.0"],
+            "tscLongitudeMin" => ["10.0"],
+            "tscLongitudeMax" => ["20.0"],
+            "tscDateStart"    => ["2026-01-01"]
+        ];
+
+        $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
+
+        $this->assertFalse($result, 'Saving should fail when longitudeMax is set but not all four coordinates are present');
+    }
+
+    /**
+     * Tests saving STC with description only and no coordinates.
+     * 
+     * This covers the scenario where a user provides only a textual spatial
+     * description without any coordinate values. The backend should allow saving
+     * this entry and store all coordinate fields as NULL.
+     *
+     * @return void
+     */
+    public function testSaveWithDescriptionOnlyAndNoCoordinates(): void
+    {
+        $resourceData = [
+            "doi" => "10.5880/GFZ.TEST.DESCRIPTION.ONLY." . uniqid(),
+            "year" => 2026,
+            "dateCreated" => "2026-01-24",
+            "resourcetype" => 1,
+            "language" => 1,
+            "Rights" => 1,
+            "title" => ["Test Description Only"],
+            "titleType" => [1]
+        ];
+        $resource_id = saveResourceInformationAndRights($this->connection, $resourceData);
+
+        $postData = [
+            "tscDescription" => ["Area described in text only"],
+            "tscDateStart"   => ["2026-01-01"]
+        ];
+
+        $result = saveSpatialTemporalCoverage($this->connection, $postData, $resource_id);
+
+        $this->assertTrue($result, 'Saving should succeed with description only and no coordinates');
+
+        $stmt = $this->connection->prepare(
+            "SELECT stc.* FROM Spatial_Temporal_Coverage stc
+             INNER JOIN Resource_has_Spatial_Temporal_Coverage rhstc
+                ON stc.spatial_temporal_coverage_id = rhstc.Spatial_Temporal_Coverage_spatial_temporal_coverage_id
+             WHERE rhstc.Resource_resource_id = ?"
+        );
+        $stmt->bind_param("i", $resource_id);
+        $stmt->execute();
+        $retrievedStc = $stmt->get_result()->fetch_assoc();
+
+        $this->assertNotNull($retrievedStc);
+        $this->assertEquals("Area described in text only", $retrievedStc["description"]);
+        $this->assertNull($retrievedStc["latitudeMin"]);
+        $this->assertNull($retrievedStc["latitudeMax"]);
+        $this->assertNull($retrievedStc["longitudeMin"]);
+        $this->assertNull($retrievedStc["longitudeMax"]);
+    }
 }

--- a/tests/js/checkMandatoryFields.module.test.js
+++ b/tests/js/checkMandatoryFields.module.test.js
@@ -133,7 +133,7 @@ describe('checkMandatoryFields module coverage', () => {
             }).not.toThrow();
         });
 
-        test('marks date fields as required when coordinates filled', () => {
+        test('DateStart and DateEnd should not be required when coordinates are filled', () => {
             $('#input-stc-latmin_1').val('52.0');
             $('#input-stc-latmax_1').val('53.0');
             $('#input-stc-longmin_1').val('13.0');
@@ -158,7 +158,7 @@ describe('checkMandatoryFields module coverage', () => {
             expect($('#input-stc-timeend').attr('required')).toBeUndefined();
         });
 
-        test('requires timezone when time is provided', () => {
+        test('when time is provided timezone should not be required', () => {
             $('#input-stc-latmin_1').val('52.0');
             $('#input-stc-datestart').val('2025-01-01');
             $('#input-stc-timestart').val('08:00');

--- a/tests/js/checkMandatoryFields.module.test.js
+++ b/tests/js/checkMandatoryFields.module.test.js
@@ -142,8 +142,8 @@ describe('checkMandatoryFields module coverage', () => {
             checkMandatoryFields.validateSpatialTemporalCoverageRequirements();
             simulateSubmitValidation();
             
-            expect($('#input-stc-datestart').attr('required')).toBe('required');
-            expect($('#input-stc-dateend').attr('required')).toBe('required');
+            expect($('#input-stc-datestart').attr('required')).not.toBe('required');
+            expect($('#input-stc-dateend').attr('required')).not.toBe('required');
         });
 
         test('does not require time fields by default', () => {
@@ -166,7 +166,16 @@ describe('checkMandatoryFields module coverage', () => {
             checkMandatoryFields.validateSpatialTemporalCoverageRequirements();
             simulateSubmitValidation();
             
-            expect($('#input-stc-timezone').attr('required')).toBe('required');
+            expect($('#input-stc-timezone').attr('required')).not.toBe('required');
+        });
+
+        test('Allow submission when only a description is provided', () => {
+            $('#input-stc-description').val('Test description');
+
+            checkMandatoryFields.validateSpatialTemporalCoverageRequirements();
+            simulateSubmitValidation();
+
+            expect($('#input-stc-latmin_1').attr('required')).not.toBe('required');
         });
 
         test('clears requirements when all fields empty', () => {

--- a/tests/js/checkMandatoryFields.test.js
+++ b/tests/js/checkMandatoryFields.test.js
@@ -194,7 +194,7 @@ describe('validateSpatialTemporalCoverageRequirements', () => {
 
     simulateSubmitValidation();
 
-    // datestart and dateend should be required
+    // datestart and dateend should not be required
     expect(datestart.prop('required')).not.toBe(true);
     expect(dateend.prop('required')).not.toBe(true);
 

--- a/tests/js/checkMandatoryFields.test.js
+++ b/tests/js/checkMandatoryFields.test.js
@@ -195,8 +195,8 @@ describe('validateSpatialTemporalCoverageRequirements', () => {
     simulateSubmitValidation();
 
     // datestart and dateend should be required
-    expect(datestart.prop('required')).toBe(true);
-    expect(dateend.prop('required')).toBe(true);
+    expect(datestart.prop('required')).not.toBe(true);
+    expect(dateend.prop('required')).not.toBe(true);
 
     // time fields should NOT be required (time is optional)
     expect(timestart.prop('required')).toBe(false);
@@ -229,9 +229,9 @@ describe('validateSpatialTemporalCoverageRequirements', () => {
     simulateSubmitValidation();
 
     // Now time fields ARE required (since a time was given)
-    expect(timestart.prop('required')).toBe(true);
-    expect(timeend.prop('required')).toBe(true);
-    expect(timezone.prop('required')).toBe(true);
+    expect(timestart.prop('required')).not.toBe(true);
+    expect(timeend.prop('required')).not.toBe(true);
+    expect(timezone.prop('required')).not.toBe(true);
   });
 
 });

--- a/tests/js/spatial-temporal-coverage-requirements.test.js
+++ b/tests/js/spatial-temporal-coverage-requirements.test.js
@@ -46,7 +46,6 @@ describe('Spatial and temporal coverage submit requirements', () => {
     global.$ = global.jQuery = $;
     window.$ = $;
     window.jQuery = $;
-    global.requestAnimationFrame = (callback) => callback();
     loadCheckMandatoryFields();
   });
 
@@ -56,11 +55,9 @@ describe('Spatial and temporal coverage submit requirements', () => {
     delete global.jQuery;
     delete window.$;
     delete window.jQuery;
-    delete window.ELMO_FEATURES;
-    delete global.requestAnimationFrame;
   });
 
-  test('spatial-only row requires temporal coverage outside ELMO-GEM', () => {
+  test('Do not set any further STC fields to required if only the min coordinates have been entered.', () => {
     $('#input-stc-latmin_1').val('-90');
     $('#input-stc-longmin_1').val('-180');
     $('#input-stc-description').val('Global spatial coverage');
@@ -68,101 +65,22 @@ describe('Spatial and temporal coverage submit requirements', () => {
     window.validateSpatialTemporalCoverageRequirements();
     simulateSubmitValidation();
 
-    expect($('#input-stc-latmin_1').prop('required')).toBe(true);
-    expect($('#input-stc-longmin_1').prop('required')).toBe(true);
-    expect($('#input-stc-description').prop('required')).toBe(true);
-    expect($('#input-stc-datestart').prop('required')).toBe(true);
-    expect($('#input-stc-dateend').prop('required')).toBe(true);
-  });
-
-  test('ELMO-GEM spatial-only row keeps description required but does not require temporal coverage', () => {
-    window.ELMO_FEATURES = { showGGMsProperties: true };
-
-    $('#input-stc-latmin_1').val('-90');
-    $('#input-stc-longmin_1').val('-180');
-    $('#input-stc-description').val('Global spatial coverage');
-
-    window.validateSpatialTemporalCoverageRequirements();
-    simulateSubmitValidation();
-
-    expect($('#input-stc-latmin_1').prop('required')).toBe(true);
-    expect($('#input-stc-longmin_1').prop('required')).toBe(true);
-    expect($('#input-stc-description').prop('required')).toBe(true);
+    expect($('#input-stc-description').prop('required')).toBe(false);
     expect($('#input-stc-datestart').prop('required')).toBe(false);
     expect($('#input-stc-dateend').prop('required')).toBe(false);
+    expect($('#input-stc-latmax_1').prop('required')).toBe(false);
+    expect($('#input-stc-longmax_1').prop('required')).toBe(false);
   });
 
-  test('ELMO-GEM spatial-only row still requires description', () => {
-    window.ELMO_FEATURES = { showGGMsProperties: true };
-
-    $('#input-stc-latmin_1').val('-90');
-    $('#input-stc-longmin_1').val('-180');
+  test('sets all coordinate fields to required if a max coordinate is filled in', () => {
+    $('#input-stc-longmax_1').val('-90');
 
     window.validateSpatialTemporalCoverageRequirements();
     simulateSubmitValidation();
 
     expect($('#input-stc-latmin_1').prop('required')).toBe(true);
     expect($('#input-stc-longmin_1').prop('required')).toBe(true);
-    expect($('#input-stc-description').prop('required')).toBe(true);
-    expect($('#input-stc-datestart').prop('required')).toBe(false);
-    expect($('#input-stc-dateend').prop('required')).toBe(false);
-  });
-
-  test('ELMO-GEM still requires dates, both times, and timezone when a time is entered', () => {
-    window.ELMO_FEATURES = { showGGMsProperties: true };
-
-    $('#input-stc-latmin_1').val('-90');
-    $('#input-stc-longmin_1').val('-180');
-    $('#input-stc-description').val('Global spatial coverage');
-    $('#input-stc-timestart').val('08:00');
-
-    window.validateSpatialTemporalCoverageRequirements();
-    simulateSubmitValidation();
-
-    expect($('#input-stc-datestart').prop('required')).toBe(true);
-    expect($('#input-stc-dateend').prop('required')).toBe(true);
-    expect($('#input-stc-timestart').prop('required')).toBe(true);
-    expect($('#input-stc-timeend').prop('required')).toBe(true);
-    expect($('#input-stc-timezone').prop('required')).toBe(true);
-  });
-
-  test('visually marks dynamically required STC fields before submit', () => {
-    $('#input-stc-longmax_1').val('14');
-
-    window.validateSpatialTemporalCoverageRequirements();
-
-    expect($('#input-stc-latmin_1').attr('aria-required')).toBe('true');
-    expect($('#input-stc-latmin_1').hasClass('border-danger')).toBe(true);
-    expect($('label[for="input-stc-latmin_1"] .stc-required-marker').text()).toBe('*');
-
-    expect($('#input-stc-longmin_1').attr('aria-required')).toBe('true');
-    expect($('#input-stc-longmin_1').hasClass('border-danger')).toBe(true);
-    expect($('label[for="input-stc-longmin_1"] .stc-required-marker').text()).toBe('*');
-
-    expect($('#input-stc-longmax_1').attr('aria-required')).toBe('true');
-    expect($('#input-stc-longmax_1').hasClass('border-danger')).toBe(false);
-    expect($('label[for="input-stc-longmax_1"] .stc-required-marker').length).toBe(0);
-
-    expect($('#input-stc-description').attr('aria-required')).toBe('true');
-    expect($('#input-stc-description').hasClass('border-danger')).toBe(true);
-    expect($('label[for="input-stc-description"] .stc-required-marker').text()).toBe('*');
-
-    expect($('#input-stc-datestart').attr('aria-required')).toBe('true');
-    expect($('#input-stc-datestart').hasClass('border-danger')).toBe(true);
-    expect($('label[for="input-stc-datestart"] .stc-required-marker').text()).toBe('*');
-
-    expect($('#input-stc-dateend').attr('aria-required')).toBe('true');
-    expect($('#input-stc-dateend').hasClass('border-danger')).toBe(true);
-    expect($('label[for="input-stc-dateend"] .stc-required-marker').text()).toBe('*');
-
-    $('#input-stc-longmax_1').val('');
-    window.validateSpatialTemporalCoverageRequirements();
-
-    expect($('#input-stc-latmin_1').attr('aria-required')).toBeUndefined();
-    expect($('#input-stc-latmin_1').hasClass('border-danger')).toBe(false);
-    expect($('label[for="input-stc-latmin_1"] .stc-required-marker').length).toBe(0);
-    expect($('#input-stc-datestart').attr('aria-required')).toBeUndefined();
-    expect($('#input-stc-datestart').hasClass('border-danger')).toBe(false);
-    expect($('label[for="input-stc-datestart"] .stc-required-marker').length).toBe(0);
+    expect($('#input-stc-description').prop('required')).toBe(false);
+    expect($('#input-stc-latmax_1').prop('required')).toBe(true);
   });
 });

--- a/tests/playwright/features/header.spec.ts
+++ b/tests/playwright/features/header.spec.ts
@@ -45,8 +45,8 @@ test.describe('Header Tests', () => {
 
     // Title should match one of the valid instance titles
     const validTitles = [
-      'ELMO – GFZ Metadata Editor 2.0',
-      'ELMO MSL Edition – GFZ Metadata Editor 2.0',
+      'ELMO – GFZ Metadata Editor',
+      'ELMO MSL Edition – GFZ Metadata Editor',
       'ELMO ICGEM Edition – Alpha Version',
       'ELMO IGSN Edition – Alpha Version'
     ];

--- a/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
+++ b/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
@@ -289,13 +289,13 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     await expect(longMin).toHaveClass(/border-danger/);
     await expect(page.locator('label[for="input-stc-longmin_1"] .stc-required-marker')).toHaveText('*');
 
-    await expect(description).toHaveAttribute('aria-required', 'true');
-    await expect(description).toHaveClass(/border-danger/);
-    await expect(page.locator('label[for="input-stc-description"] .stc-required-marker')).toHaveText('*');
+    await expect(description).not.toHaveAttribute('aria-required', 'true');
+    await expect(description).not.toHaveClass(/border-danger/);
+    await expect(page.locator('label[for="input-stc-description"] .stc-required-marker')).toHaveCount(0);
 
-    await expect(startDate).toHaveAttribute('aria-required', 'true');
-    await expect(startDate).toHaveClass(/border-danger/);
-    await expect(page.locator('label[for="input-stc-datestart"] .stc-required-marker')).toHaveText('*');
+    await expect(startDate).not.toHaveAttribute('aria-required', 'true');
+    await expect(startDate).not.toHaveClass(/border-danger/);
+    await expect(page.locator('label[for="input-stc-datestart"] .stc-required-marker')).toHaveCount(0);
 
     await expect(longMax).toHaveAttribute('aria-required', 'true');
     await expect(longMax).not.toHaveClass(/border-danger/);
@@ -461,7 +461,7 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     await expect(timezoneSelect).not.toHaveClass(/is-invalid/);
   });
 
-  test('makes timezone required when time fields are filled', async ({ page }) => {
+  test('time zone should be optional even if the time fields are filled in', async ({ page }) => {
     // Verify timezone is NOT required initially
     const timezoneSelect = page.locator('#input-stc-timezone');
     await expect(timezoneSelect).not.toHaveAttribute('required');
@@ -492,7 +492,7 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     await simulateSubmitValidation(page);
 
     // Timezone should now be required when time is provided
-    await expect(timezoneSelect).toHaveAttribute('required');
+    await expect(timezoneSelect).not.toHaveAttribute('required');
   });
 
   test('keeps STC submit validation highlights visible when fields must be filled in', async ({ page }) => {
@@ -508,8 +508,8 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
 
     await expect(latMin).toHaveAttribute('aria-required', 'true');
     await expect(longMin).toHaveAttribute('aria-required', 'true');
-    await expect(description).toHaveAttribute('aria-required', 'true');
-    await expect(startDate).toHaveAttribute('aria-required', 'true');
+    await expect(description).not.toHaveAttribute('aria-required', 'true');
+    await expect(startDate).not.toHaveAttribute('aria-required', 'true');
 
     // Submit with missing required STC fields
     await simulateSubmitValidation(page);
@@ -517,8 +517,8 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     // Required-but-empty fields must stay highlighted after failed submit
     await expect(latMin).toHaveClass(/border-danger/);
     await expect(longMin).toHaveClass(/border-danger/);
-    await expect(description).toHaveClass(/border-danger/);
-    await expect(startDate).toHaveClass(/border-danger/);
+    await expect(description).not.toHaveClass(/border-danger/);
+    await expect(startDate).not.toHaveClass(/border-danger/);
 
     // The filled trigger field should not be highlighted as missing
     await expect(longMax).not.toHaveClass(/border-danger/);
@@ -529,8 +529,8 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
 
     await expect(latMin).toHaveClass(/border-danger/);
     await expect(longMin).toHaveClass(/border-danger/);
-    await expect(description).toHaveClass(/border-danger/);
-    await expect(startDate).toHaveClass(/border-danger/);
+    await expect(description).not.toHaveClass(/border-danger/);
+    await expect(startDate).not.toHaveClass(/border-danger/);
 
     // Once the fields are fixed, the red highlight should disappear
     await latMin.fill('52.0');

--- a/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
+++ b/tests/playwright/formgroups/spatial-temporal-coverages.spec.ts
@@ -494,4 +494,54 @@ test.describe('Spatial and Temporal Coverages Form Group', () => {
     // Timezone should now be required when time is provided
     await expect(timezoneSelect).toHaveAttribute('required');
   });
+
+  test('keeps STC submit validation highlights visible when fields must be filled in', async ({ page }) => {
+    const longMax = page.locator('#input-stc-longmax_1');
+    const latMin = page.locator('#input-stc-latmin_1');
+    const longMin = page.locator('#input-stc-longmin_1');
+    const description = page.locator('#input-stc-description');
+    const startDate = page.locator('#input-stc-datestart');
+
+    // Trigger STC dependency rules: this makes companion fields required-on-submit
+    await longMax.fill('14');
+    await longMax.blur();
+
+    await expect(latMin).toHaveAttribute('aria-required', 'true');
+    await expect(longMin).toHaveAttribute('aria-required', 'true');
+    await expect(description).toHaveAttribute('aria-required', 'true');
+    await expect(startDate).toHaveAttribute('aria-required', 'true');
+
+    // Submit with missing required STC fields
+    await simulateSubmitValidation(page);
+
+    // Required-but-empty fields must stay highlighted after failed submit
+    await expect(latMin).toHaveClass(/border-danger/);
+    await expect(longMin).toHaveClass(/border-danger/);
+    await expect(description).toHaveClass(/border-danger/);
+    await expect(startDate).toHaveClass(/border-danger/);
+
+    // The filled trigger field should not be highlighted as missing
+    await expect(longMax).not.toHaveClass(/border-danger/);
+
+    // Revalidation / follow-up events must not clear the red highlight
+    await longMax.blur();
+    await page.waitForTimeout(150);
+
+    await expect(latMin).toHaveClass(/border-danger/);
+    await expect(longMin).toHaveClass(/border-danger/);
+    await expect(description).toHaveClass(/border-danger/);
+    await expect(startDate).toHaveClass(/border-danger/);
+
+    // Once the fields are fixed, the red highlight should disappear
+    await latMin.fill('52.0');
+    await longMin.fill('13.0');
+    await description.fill('Test coverage area');
+    await startDate.fill('2024-01-15');
+    await startDate.blur();
+
+    await expect(latMin).not.toHaveClass(/border-danger/);
+    await expect(longMin).not.toHaveClass(/border-danger/);
+    await expect(description).not.toHaveClass(/border-danger/);
+    await expect(startDate).not.toHaveClass(/border-danger/);
+  });
 });


### PR DESCRIPTION
This code change refines the Spatial and Temporal Coverage (STC) validation and makes the rules less strict while keeping data consistent.

The validation logic has been updated in both the frontend and the backend, the automated tests on both sides have been adjusted and extended, and the documentation was updated.

#1165

## Changes

- Relaxed STC coordinate and date requirements to match the new rules (mins fields earn points; if one is filled in, the other must be too. and If one of the max fields is filled in, all fields must become mandatory.)
- Aligned backend validation with the frontend behavior
- Adjusted and extended PHPUnit, jest-test and Playwright tests for STC
- Updated STC documentation(Guide and Readme)

## Notes for Reviewer
**ELMO version**: I’ve removed the numbers next to the title. Unfortunately, however, I can’t update the version in the changelog, as we already have the new version in `dev` but not in `main`. And if we were to merge `dev` into `main`, that would also bring in other implementations, the ones @Daetha merged this morning. For this reason, I’ll leave out the version number this time.

## Checklist

### Branching Strategy:
If this is a hotfix: The branch was created from `main` and will be merged into `main`.
If this is a feature or documentation change: The branch was created from `dev` and will be merged into `dev`.
If this is a feature or documentation branch, I have pulled the latest changes from `main` into my branch.

### Code Quality
- [x] My code follows the style guide.
- [x] I have self-reviewed my code.
- [x] I added comments for hard-to-understand code.
- [x] My changes do not create new warnings in the browser console.

### Documentation
- [x] If applicable, PHP code is documented using PHPDoc.
- [x] If applicable, JavaScript code is documented using JSDoc.
- [x] If needed, the ELMO Guide ('./doc/help.html') has been updated.
- [x] If needed, the README has been updated.
- [x] If needed, the API documentation ('./api/v2/docs') has been updated.
- [x] If a new feature was added or a bug fixed, the changelog ('./doc/changelog.html') has been updated.

### Testing
- [x] If needed, Playwright tests have been updated or added.
- [x] If needed, unit tests have been updated or added.
- [x] If needed, jest tests have been updated or added.


## Known Issues
Nothing